### PR TITLE
Fix/#52 search results for all search keywords are not used in semantic scholar retriever

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ cython_debug/
 .DS_Store
 !.gitkeep
 data/*
+.gitmessage.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "llmlinks==0.1.34",
     "openai>=1.35.13",
     "pyalex>=0.15.1",
+    "pydantic>=2.9.2",
     "pypdf>=4.3.1",
     "semanticscholar>=0.8.4",
     "tomli-w>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2399,7 +2399,7 @@ wheels = [
 
 [[package]]
 name = "researchgraph"
-version = "0.0.7"
+version = "0.0.8"
 source = { virtual = "." }
 dependencies = [
     { name = "langchain" },
@@ -2408,6 +2408,7 @@ dependencies = [
     { name = "llmlinks" },
     { name = "openai" },
     { name = "pyalex" },
+    { name = "pydantic" },
     { name = "pypdf" },
     { name = "semanticscholar" },
     { name = "tomli" },
@@ -2431,6 +2432,7 @@ requires-dist = [
     { name = "llmlinks", specifier = "==0.1.34" },
     { name = "openai", specifier = ">=1.35.13" },
     { name = "pyalex", specifier = ">=0.15.1" },
+    { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pypdf", specifier = ">=4.3.1" },
     { name = "semanticscholar", specifier = ">=0.8.4" },
     { name = "tomli", specifier = ">=2.0.1" },


### PR DESCRIPTION
Fixed an implementation in semantic_scholar.py where only the last result of all_search_results was used for the search.