### PR TITLE
Fix/#96 modify test writingnodepy on the local

### DIFF
--- a/test/test_writingnode.py
+++ b/test/test_writingnode.py
@@ -15,7 +15,7 @@ class State(TypedDict):
 
 
 SAVE_DIR = os.environ.get("SAVE_DIR", "/workspaces/researchgraph/data")
-GITHUB_WORKSPACE = os.environ.get("GITHUB_WORKSPACE", os.path.abspath(os.path.join(os.getcwd())))
+GITHUB_WORKSPACE = os.environ.get("GITHUB_WORKSPACE", os.path.abspath(os.path.join(os.getcwd(), "..")))
 
 def test_latex_node():
     # Define input and output keys


### PR DESCRIPTION
### Overview
This PR fixes the `template_dir` path used in the `test_writingnode.py` script.