### PR TITLE
Update ReviewNode

### DIFF
--- a/src/researchgraph/review_subgraph/input_data.py
+++ b/src/researchgraph/review_subgraph/input_data.py
@@ -1,316 +1,327 @@
 review_subgraph_input_data = {
-    "review_decision": False, 
+    "review_routing": None, 
     "review_feedback": "", 
-    "tex_text": r"""
-\documentclass{article} % For LaTeX2e
-\usepackage{iclr2024_conference,times}
 
-\usepackage[utf8]{inputenc} % allow utf-8 input
-\usepackage[T1]{fontenc}    % use 8-bit T1 fonts
-\usepackage{hyperref}       % hyperlinks
-\usepackage{url}            % simple URL typesetting
-\usepackage{booktabs}       % professional-quality tables
-\usepackage{amsfonts}       % blackboard math symbols
-\usepackage{nicefrac}       % compact symbols for 1/2, etc.
-\usepackage{microtype}      % microtypography
-\usepackage{titletoc}
-
-\usepackage{subcaption}
-\usepackage{graphicx}
-\usepackage{amsmath}
-\usepackage{multirow}
-\usepackage{color}
-\usepackage{colortbl}
-\usepackage{cleveref}
-\usepackage{algorithm}
-\usepackage{algorithmicx}
-\usepackage{algpseudocode}
-
-\DeclareMathOperator*{\argmin}{arg\,min}
-\DeclareMathOperator*{\argmax}{arg\,max}
-
-\graphicspath{{../}} % To reference your generated figures, see below.
-\begin{filecontents}{references.bib}
-@article{lu2024aiscientist,
-  title={The {AI} {S}cientist: Towards Fully Automated Open-Ended Scientific Discovery},
-  author={Lu, Chris and Lu, Cong and Lange, Robert Tjarko and Foerster, Jakob and Clune, Jeff and Ha, David},
-  journal={arXiv preprint arXiv:2408.06292},
-  year={2024}
+    "verification_policy": "",
+    "experiment_details": "",
+    "experiment_code": """
+    #!/usr/bin/env python This script contains the following experiments: 1. Synthetic Optimization Benchmark (Convex Quadratic and Rosenbrock-like functions) 2. Deep Neural Network Training on CIFAR-10 using a simple CNN 3. Ablation Study & Hyperparameter Sensitivity Analysis on MNIST Each experiment compares a custom Adaptive Curvature Momentum (ACM) optimizer against established optimizers (Adam, SGD with momentum). The ACM optimizer adjusts per-parameter learning rates using a simple curvature-estimate (the difference between successive gradients) and uses momentum buffering. A quick_test() function is provided to run minimal iterations (to verify code execution). import torch import torch.nn as nn import torch.optim as optim import torchvision import torchvision.transforms as transforms import matplotlib.pyplot as plt import numpy as np import time ################################################################################ # 1. Synthetic Optimization Benchmark ################################################################################ # Define the ACM optimizer (for synthetic experiments and later deep-learning tests) class ACMOptimizer(optim.Optimizer): def __init__(self, params, lr=0.01, beta=0.9, curvature_influence=0.1): # The momentum_buffer variable will be stored in state, so we do not initialize it in defaults. defaults = dict(lr=lr, beta=beta, curvature_influence=curvature_influence) super(ACMOptimizer, self).__init__(params, defaults) def step(self, closure=None): loss = None if closure is not None: loss = closure() # Only single parameter group is assumed in this simple implementation. for group in self.param_groups: lr = group['lr'] beta = group['beta'] curvature_influence = group['curvature_influence'] for p in group['params']: if p.grad is None: continue grad = p.grad.data state = self.state[p] if 'momentum_buffer' not in state: # For the very first update, simply store the current gradient. state['momentum_buffer'] = torch.clone(grad).detach() p.data.add_(-lr * grad) else: buf = state['momentum_buffer'] # Estimate curvature simply as the absolute difference between current gradient and previous momentum. curvature_est = (grad - buf).abs() # Compute an adaptive per-component learning rate. adaptive_lr = lr / (1.0 + curvature_influence * curvature_est) # Update the momentum buffer with exponential moving average. buf.mul_(beta).add_(grad, alpha=1 - beta) # Update parameters using (elementwise) adaptive learning rate and momentum buffer. p.data.add_(-adaptive_lr * buf) return loss # Define a convex quadratic function: f(x) = 0.5 * x^T A x - b^T x. def quadratic_loss(x, A, b): return 0.5 * x @ A @ x - b @ x # Define a modified Rosenbrock-like function (a simple nonconvex function) def rosenbrock_loss(x): # Here x is assumed to be a 2D tensor. a = 1.0 b = 100.0 return (a - x[0])**2 + b * (x[1] - x[0]**2)**2 def run_synthetic_experiment(num_iters=100): print("=== Synthetic Experiment: Quadratic Function Optimization ===") torch.manual_seed(0) # Example 2D quadratic. A is positive definite. A = torch.tensor([[3.0, 0.2], [0.2, 2.0]]) b = torch.tensor([1.0, 1.0]) # Prepare optimizers for each method. optimizers_dict = { "ACM": ACMOptimizer, "Adam": optim.Adam, "SGD_mom": lambda params, lr: optim.SGD(params, lr=lr, momentum=0.9) } results = {name: [] for name in optimizers_dict.keys()} # Run separate optimization runs for each optimizer starting with a new initial point. for name, opt_class in optimizers_dict.items(): print(f"\nRunning optimization with {name}") # reinitialize the initial point for fairness x_data = torch.randn(2, requires_grad=True) # Instantiate the optimizer. if name == "ACM": optimizer = opt_class([x_data], lr=0.1, beta=0.9, curvature_influence=0.05) else: optimizer = opt_class([x_data], lr=0.1) for i in range(num_iters): optimizer.zero_grad() loss = quadratic_loss(x_data, A, b) loss.backward() optimizer.step() results[name].append(loss.item()) if (i + 1) % (num_iters // 5) == 0 or i == 0: print(f"Iter {i+1}/{num_iters} - Loss: {loss.item():.4f}") # Plot the convergence curves. plt.figure() for name, losses in results.items(): plt.plot(losses, label=name) plt.xlabel("Iteration") plt.ylabel("Loss") plt.title("Quadratic Function Optimization") plt.legend() plt.show()
+    """,
+    "output_text_data": """
+    ================================================================================ === RUNNING QUICK TEST OF ACM OPTIMIZER === ================================================================================ Python version: 3.10.16 (main, Dec 12 2024, 19:07:39) [GCC 11.4.0] PyTorch version: 2.6.0+cu124 Using device: cuda GPU: Tesla T4 GPU Memory: 16.71 GB -------------------------------------------------------------------------------- QUICK TEST CONFIGURATION: Random seed: 42 -------------------------------------------------------------------------------- ================================================================================ === QUICK TEST: SYNTHETIC OPTIMIZATION BENCHMARK === ================================================================================ Running synthetic optimization benchmarks with ACM, Adam, and SGD+momentum... Functions: Quadratic and Rosenbrock === Synthetic Optimization Benchmark === Running optimization with ACM Iter 1/20 - Loss: 2.4565 Iter 4/20 - Loss: 2.4501 Iter 8/20 - Loss: 2.4305 Iter 12/20 - Loss: 2.4024 Iter 16/20 - Loss: 2.3688 Iter 20/20 - Loss: 2.3319 Running optimization with Adam Iter 1/20 - Loss: 0.0068 Iter 4/20 - Loss: 0.0015 Iter 8/20 - Loss: -0.0056 Iter 12/20 - Loss: -0.0126 Iter 16/20 - Loss: -0.0194 Iter 20/20 - Loss: -0.0262 Running optimization with SGD_momentum Iter 1/20 - Loss: 1.0733 Iter 4/20 - Loss: 1.0335 Iter 8/20 - Loss: 0.9149 Iter 12/20 - Loss: 0.7572 Iter 16/20 - Loss: 0.5884 Iter 20/20 - Loss: 0.4260 === Rosenbrock Function Optimization === Running optimization with ACM Iter 1/20 - Loss: 1.0000 Iter 4/20 - Loss: 0.9978 Iter 8/20 - Loss: 0.9908 Iter 12/20 - Loss: 0.9808 Iter 16/20 - Loss: 0.9690 Iter 20/20 - Loss: 0.9559 Running optimization with Adam Iter 1/20 - Loss: 1.0000 Iter 4/20 - Loss: 0.9940 Iter 8/20 - Loss: 0.9861 Iter 12/20 - Loss: 0.9781 Iter 16/20 - Loss: 0.9703 Iter 20/20 - Loss: 0.9624 Running optimization with SGD_momentum Iter 1/20 - Loss: 1.0000 Iter 4/20 - Loss: 0.9777 Iter 8/20 - Loss: 0.9110 Iter 12/20 - Loss: 0.8221 Iter 16/20 - Loss: 0.7266 Iter 20/20 - Loss: 0.6347 === Synthetic Optimization Results === Quadratic Function Optimization: Final Loss Values: ACM: 2.331910 Adam: -0.026165 SGD_momentum: 0.425952 Final Positions: ACM: [0.19387202 2.1209867 ] Adam: [ 0.15900403 -0.08826145] SGD_momentum: [-0.26321486  1.0717224 ] Rosenbrock Function Optimization: Final Loss Values: ACM: 0.955919 Adam: 0.962407 SGD_momentum: 0.634735 Final Positions: ACM: [0.02402827 0.00014844] Adam: [0.01997579 0.00064254] SGD_momentum: [0.21810871 0.04335106] Convergence Analysis: Quadratic Function: ACM avg loss reduction per iteration: 0.00697672 ACM did not reach 1% of initial loss Adam avg loss reduction per iteration: 0.00126349 Adam iterations to reach 1% of initial loss: 4 SGD_momentum avg loss reduction per iteration: 0.03018586 SGD_momentum did not reach 1% of initial loss Rosenbrock Function: ACM avg loss reduction per iteration: 0.00246692 ACM did not reach 1% of initial loss Adam avg loss reduction per iteration: 0.00146969 Adam did not reach 1% of initial loss SGD_momentum avg loss reduction per iteration: 0.01706579 SGD_momentum did not reach 1% of initial loss ================================================================================ === QUICK TEST: CIFAR-10 CNN TRAINING === ================================================================================ Loading CIFAR-10 dataset... Training CNN models on CIFAR-10 with different optimizers... === CIFAR-10 CNN Training === Training with ACM optimizer Epoch 1/1 - Train Loss: 2.3023, Test Accuracy: 9.93% Training with Adam optimizer Epoch 1/1 - Train Loss: 1.5870, Test Accuracy: 54.79% Training with SGD_momentum optimizer Epoch 1/1 - Train Loss: 2.2435, Test Accuracy: 24.83% === CIFAR-10 Training Results === Final Training Loss: ACM: 2.3023 Adam: 1.5870 SGD_momentum: 2.2435 Final Test Accuracy: ACM: 9.93% Adam: 54.79% SGD_momentum: 24.83% Convergence Speed (epochs to reach 90% of final accuracy): ACM: 1 Adam: 1 SGD_momentum: 1 ================================================================================ === QUICK TEST: MNIST ABLATION STUDY === ================================================================================ Loading MNIST dataset... Running ablation study with different curvature influence parameters... === MNIST Ablation Study === Training with ACM_curv_0.0 Epoch 1/1 - Train Loss: 2.2709, Test Accuracy: 38.82% Training with ACM_curv_0.1 Epoch 1/1 - Train Loss: 2.2739, Test Accuracy: 29.41% Training with ACM_curv_1.0 Epoch 1/1 - Train Loss: 2.2359, Test Accuracy: 35.35% Training with Adam Epoch 1/1 - Train Loss: 0.2508, Test Accuracy: 98.10% Training with SGD_momentum Epoch 1/1 - Train Loss: 1.3806, Test Accuracy: 88.93% === MNIST Ablation Study Results === Final Training Loss: ACM_curv_0.0: 2.2709 ACM_curv_0.1: 2.2739 ACM_curv_1.0: 2.2359 Adam: 0.2508 SGD_momentum: 1.3806 Final Test Accuracy: ACM_curv_0.0: 38.82% ACM_curv_0.1: 29.41% ACM_curv_1.0: 35.35% Adam: 98.10% SGD_momentum: 88.93% Effect of Curvature Influence Parameter: Curvature influence = 0.0: 38.82% Curvature influence = 0.1: 29.41% Curvature influence = 1.0: 35.35% ================================================================================ === QUICK TEST COMPLETED SUCCESSFULLY === ================================================================================
+    """,    
 }
 
-@book{goodfellow2016deep,
-  title={Deep learning},
-  author={Goodfellow, Ian and Bengio, Yoshua and Courville, Aaron and Bengio, Yoshua},
-  volume={1},
-  year={2016},
-  publisher={MIT Press}
-}
 
-@article{yang2023diffusion,
-  title={Diffusion models: A comprehensive survey of methods and applications},
-  author={Yang, Ling and Zhang, Zhilong and Song, Yang and Hong, Shenda and Xu, Runsheng and Zhao, Yue and Zhang, Wentao and Cui, Bin and Yang, Ming-Hsuan},
-  journal={ACM Computing Surveys},
-  volume={56},
-  number={4},
-  pages={1--39},
-  year={2023},
-  publisher={ACM New York, NY, USA}
-}
+#     "tex_text": r"""
+# \documentclass{article} % For LaTeX2e
+# \usepackage{iclr2024_conference,times}
 
-@inproceedings{ddpm,
- author = {Ho, Jonathan and Jain, Ajay and Abbeel, Pieter},
- booktitle = {Advances in Neural Information Processing Systems},
- editor = {H. Larochelle and M. Ranzato and R. Hadsell and M.F. Balcan and H. Lin},
- pages = {6840--6851},
- publisher = {Curran Associates, Inc.},
- title = {Denoising Diffusion Probabilistic Models},
- url = {https://proceedings.neurips.cc/paper/2020/file/4c5bcfec8584af0d967f1ab10179ca4b-Paper.pdf},
- volume = {33},
- year = {2020}
-}
+# \usepackage[utf8]{inputenc} % allow utf-8 input
+# \usepackage[T1]{fontenc}    % use 8-bit T1 fonts
+# \usepackage{hyperref}       % hyperlinks
+# \usepackage{url}            % simple URL typesetting
+# \usepackage{booktabs}       % professional-quality tables
+# \usepackage{amsfonts}       % blackboard math symbols
+# \usepackage{nicefrac}       % compact symbols for 1/2, etc.
+# \usepackage{microtype}      % microtypography
+# \usepackage{titletoc}
 
-@inproceedings{vae,
-  added-at = {2020-10-15T14:36:56.000+0200},
-  author = {Kingma, Diederik P. and Welling, Max},
-  biburl = {https://www.bibsonomy.org/bibtex/242e5be6faa01cba2587f4907ac99dce8/annakrause},
-  booktitle = {2nd International Conference on Learning Representations, {ICLR} 2014, Banff, AB, Canada, April 14-16, 2014, Conference Track Proceedings},
-  eprint = {http://arxiv.org/abs/1312.6114v10},
-  eprintclass = {stat.ML},
-  eprinttype = {arXiv},
-  file = {:http\://arxiv.org/pdf/1312.6114v10:PDF;:KingmaWelling_Auto-EncodingVariationalBayes.pdf:PDF},
-  interhash = {a626a9d77a123c52405a08da983203cb},
-  intrahash = {42e5be6faa01cba2587f4907ac99dce8},
-  keywords = {cs.LG stat.ML vae},
-  timestamp = {2021-02-01T17:13:18.000+0100},
-  title = {{Auto-Encoding Variational Bayes}},
-  year = 2014
-}
+# \usepackage{subcaption}
+# \usepackage{graphicx}
+# \usepackage{amsmath}
+# \usepackage{multirow}
+# \usepackage{color}
+# \usepackage{colortbl}
+# \usepackage{cleveref}
+# \usepackage{algorithm}
+# \usepackage{algorithmicx}
+# \usepackage{algpseudocode}
 
-@inproceedings{gan,
- author = {Goodfellow, Ian and Pouget-Abadie, Jean and Mirza, Mehdi and Xu, Bing and Warde-Farley, David and Ozair, Sherjil and Courville, Aaron and Bengio, Yoshua},
- booktitle = {Advances in Neural Information Processing Systems},
- editor = {Z. Ghahramani and M. Welling and C. Cortes and N. Lawrence and K.Q. Weinberger},
- pages = {},
- publisher = {Curran Associates, Inc.},
- title = {Generative Adversarial Nets},
- url = {https://proceedings.neurips.cc/paper/2014/file/5ca3e9b122f61f8f06494c97b1afccf3-Paper.pdf},
- volume = {27},
- year = {2014}
-}
+# \DeclareMathOperator*{\argmin}{arg\,min}
+# \DeclareMathOperator*{\argmax}{arg\,max}
 
-@InProceedings{pmlr-v37-sohl-dickstein15,
-  title = \t {Deep Unsupervised Learning using Nonequilibrium Thermodynamics},
-  author = \t {Sohl-Dickstein, Jascha and Weiss, Eric and Maheswaranathan, Niru and Ganguli, Surya},
-  booktitle = \t {Proceedings of the 32nd International Conference on Machine Learning},
-  pages = \t {2256--2265},
-  year = \t {2015},
-  editor = \t {Bach, Francis and Blei, David},
-  volume = \t {37},
-  series = \t {Proceedings of Machine Learning Research},
-  address = \t {Lille, France},
-  month = \t {07--09 Jul},
-  publisher =    {PMLR}
-}
+# \graphicspath{{../}} % To reference your generated figures, see below.
+# \begin{filecontents}{references.bib}
+# @article{lu2024aiscientist,
+#   title={The {AI} {S}cientist: Towards Fully Automated Open-Ended Scientific Discovery},
+#   author={Lu, Chris and Lu, Cong and Lange, Robert Tjarko and Foerster, Jakob and Clune, Jeff and Ha, David},
+#   journal={arXiv preprint arXiv:2408.06292},
+#   year={2024}
+# }
 
-@inproceedings{
-edm,
-title={Elucidating the Design Space of Diffusion-Based Generative Models},
-author={Tero Karras and Miika Aittala and Timo Aila and Samuli Laine},
-booktitle={Advances in Neural Information Processing Systems},
-editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
-year={2022},
-url={https://openreview.net/forum?id=k7FuTOWMOc7}
-}
+# @book{goodfellow2016deep,
+#   title={Deep learning},
+#   author={Goodfellow, Ian and Bengio, Yoshua and Courville, Aaron and Bengio, Yoshua},
+#   volume={1},
+#   year={2016},
+#   publisher={MIT Press}
+# }
 
-@misc{kotelnikov2022tabddpm,
-      title={TabDDPM: Modelling Tabular Data with Diffusion Models}, 
-      author={Akim Kotelnikov and Dmitry Baranchuk and Ivan Rubachev and Artem Babenko},
-      year={2022},
-      eprint={2209.15421},
-      archivePrefix={arXiv},
-      primaryClass={cs.LG}
-}
+# @article{yang2023diffusion,
+#   title={Diffusion models: A comprehensive survey of methods and applications},
+#   author={Yang, Ling and Zhang, Zhilong and Song, Yang and Hong, Shenda and Xu, Runsheng and Zhao, Yue and Zhang, Wentao and Cui, Bin and Yang, Ming-Hsuan},
+#   journal={ACM Computing Surveys},
+#   volume={56},
+#   number={4},
+#   pages={1--39},
+#   year={2023},
+#   publisher={ACM New York, NY, USA}
+# }
 
-\end{filecontents}
+# @inproceedings{ddpm,
+#  author = {Ho, Jonathan and Jain, Ajay and Abbeel, Pieter},
+#  booktitle = {Advances in Neural Information Processing Systems},
+#  editor = {H. Larochelle and M. Ranzato and R. Hadsell and M.F. Balcan and H. Lin},
+#  pages = {6840--6851},
+#  publisher = {Curran Associates, Inc.},
+#  title = {Denoising Diffusion Probabilistic Models},
+#  url = {https://proceedings.neurips.cc/paper/2020/file/4c5bcfec8584af0d967f1ab10179ca4b-Paper.pdf},
+#  volume = {33},
+#  year = {2020}
+# }
 
-\title{Adaptive Optimization of Stochastic Systems with Gradient-based Methods}
+# @inproceedings{vae,
+#   added-at = {2020-10-15T14:36:56.000+0200},
+#   author = {Kingma, Diederik P. and Welling, Max},
+#   biburl = {https://www.bibsonomy.org/bibtex/242e5be6faa01cba2587f4907ac99dce8/annakrause},
+#   booktitle = {2nd International Conference on Learning Representations, {ICLR} 2014, Banff, AB, Canada, April 14-16, 2014, Conference Track Proceedings},
+#   eprint = {http://arxiv.org/abs/1312.6114v10},
+#   eprintclass = {stat.ML},
+#   eprinttype = {arXiv},
+#   file = {:http\://arxiv.org/pdf/1312.6114v10:PDF;:KingmaWelling_Auto-EncodingVariationalBayes.pdf:PDF},
+#   interhash = {a626a9d77a123c52405a08da983203cb},
+#   intrahash = {42e5be6faa01cba2587f4907ac99dce8},
+#   keywords = {cs.LG stat.ML vae},
+#   timestamp = {2021-02-01T17:13:18.000+0100},
+#   title = {{Auto-Encoding Variational Bayes}},
+#   year = 2014
+# }
 
-\author{GPT-4o \& Claude\\
-Department of Computer Science\\
-University of LLMs\\
-}
+# @inproceedings{gan,
+#  author = {Goodfellow, Ian and Pouget-Abadie, Jean and Mirza, Mehdi and Xu, Bing and Warde-Farley, David and Ozair, Sherjil and Courville, Aaron and Bengio, Yoshua},
+#  booktitle = {Advances in Neural Information Processing Systems},
+#  editor = {Z. Ghahramani and M. Welling and C. Cortes and N. Lawrence and K.Q. Weinberger},
+#  pages = {},
+#  publisher = {Curran Associates, Inc.},
+#  title = {Generative Adversarial Nets},
+#  url = {https://proceedings.neurips.cc/paper/2014/file/5ca3e9b122f61f8f06494c97b1afccf3-Paper.pdf},
+#  volume = {27},
+#  year = {2014}
+# }
 
-\newcommand{\fix}{\marginpar{FIX}}
-\newcommand{\new}{\marginpar{NEW}}
+# @InProceedings{pmlr-v37-sohl-dickstein15,
+#   title = \t {Deep Unsupervised Learning using Nonequilibrium Thermodynamics},
+#   author = \t {Sohl-Dickstein, Jascha and Weiss, Eric and Maheswaranathan, Niru and Ganguli, Surya},
+#   booktitle = \t {Proceedings of the 32nd International Conference on Machine Learning},
+#   pages = \t {2256--2265},
+#   year = \t {2015},
+#   editor = \t {Bach, Francis and Blei, David},
+#   volume = \t {37},
+#   series = \t {Proceedings of Machine Learning Research},
+#   address = \t {Lille, France},
+#   month = \t {07--09 Jul},
+#   publisher =    {PMLR}
+# }
 
-\begin{document}
+# @inproceedings{
+# edm,
+# title={Elucidating the Design Space of Diffusion-Based Generative Models},
+# author={Tero Karras and Miika Aittala and Timo Aila and Samuli Laine},
+# booktitle={Advances in Neural Information Processing Systems},
+# editor={Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho},
+# year={2022},
+# url={https://openreview.net/forum?id=k7FuTOWMOc7}
+# }
 
-\maketitle
+# @misc{kotelnikov2022tabddpm,
+#       title={TabDDPM: Modelling Tabular Data with Diffusion Models}, 
+#       author={Akim Kotelnikov and Dmitry Baranchuk and Ivan Rubachev and Artem Babenko},
+#       year={2022},
+#       eprint={2209.15421},
+#       archivePrefix={arXiv},
+#       primaryClass={cs.LG}
+# }
 
-\begin{abstract}
-The Adam optimization algorithm (ADaptive Moment estimation) has emerged as a pioneering approach for tackling stochastic optimization problems encountered in machine learning, particularly in neural network training. This work comprehensively addresses the inherent challenges of high-dimensional parameter spaces, sparse and noisy gradients, and non-stationary objectives associated with traditional optimization methods. Adam uniquely amalgamates the advantages of AdaGrad and RMSProp, implementing adaptive learning rates for each parameter coupled with bias-corrected moment estimates to ensure stability and convergence. Featuring a computational complexity proportional to the model parameters, Adam remains efficient and scalable across diverse applications. Empirical evaluations underscore Adam's remarkable convergence rates and enhanced stability under various experimental setups, effectively outperforming state-of-the-art optimizers like stochastic gradient descent. This study not only elaborates on theoretical advancements but also demonstrates practical implementation insights and results, consolidating Adam's instrumental role in advancing scalable and efficient machine learning solutions.
-\end{abstract}
+# \end{filecontents}
 
-\section{Introduction}
-\label{sec:intro}
-Adam, an acronym for Adaptive Moment Estimation, signifies a pivotal innovation in optimization methodologies within the realm of machine learning. The seminal paper \textit{Adam: A Method for Stochastic Optimization} introduces this algorithm and highlights its value in tackling complex challenges such as high-dimensional parameter spaces, stochastic objective functions, and noisy gradient calculations. Adam amalgamates concepts from momentum-based methods and adaptivity found in RMSprop, enabling dynamic adjustment of learning rates on a per-parameter basis by utilizing estimates of the first and second moments of the gradients. This approach enhances both convergence speed and stability.
+# \title{Adaptive Optimization of Stochastic Systems with Gradient-based Methods}
 
-Adam is particularly adept in scenarios where conventional methods face difficulties, such as in environments characterized by sparse gradients or significant gradient noise. By minimizing dependency on manual hyperparameter tuning, the algorithm facilitates widespread applicability across varied machine learning tasks. Its simplicity in implementation, coupled with robust performance, underscores its critical role in training neural networks, where optimization processes profoundly influence model accuracy and generalization.
+# \author{GPT-4o \& Claude\\
+# Department of Computer Science\\
+# University of LLMs\\
+# }
 
-The publication meticulously details Adam's algorithmic mechanism, illustrating its superiority through comparative analyses against predecessors, such as AdaGrad and RMSprop. It demonstrates Adam's capabilities in not only achieving faster convergence but also in handling diversified optimization landscapes effectively. To support practical applications, the paper provides guidance on parameter initialization and offers pseudocode for seamless integration by researchers and practitioners.
+# \newcommand{\fix}{\marginpar{FIX}}
+# \newcommand{\new}{\marginpar{NEW}}
 
-Moreover, the authors discuss extensibility avenues, proposing enhancements that cater to evolving demands in machine learning. This includes adjustments to ensure better stabilization and integration into sophisticated optimization frameworks. Consequently, Adam's introduction not only marks a transformative milestone but also lays the groundwork for continued exploration and refinement of optimization algorithms within the field.
+# \begin{document}
 
-To summarize the contributions of the introduced Adam optimization method:
-\begin{itemize}
-    \item A novel algorithm combining strengths of momentum and adaptivity for enhanced performance.
-    \item Demonstration of superior handling of challenges in stochastic, high-dimensional optimization problems.
-    \item Provision of practical guidance for implementation and parameter settings to benefit varied machine learning undertakings.
-    \item Exploration of potential future developments ensuring the algorithm's sustained relevance.
-\end{itemize}
+# \maketitle
 
-\section{Related Work}
-\label{sec:related}
-\subsection{Comparative Analysis of Optimization Methods}
+# \begin{abstract}
+# The Adam optimization algorithm (ADaptive Moment estimation) has emerged as a pioneering approach for tackling stochastic optimization problems encountered in machine learning, particularly in neural network training. This work comprehensively addresses the inherent challenges of high-dimensional parameter spaces, sparse and noisy gradients, and non-stationary objectives associated with traditional optimization methods. Adam uniquely amalgamates the advantages of AdaGrad and RMSProp, implementing adaptive learning rates for each parameter coupled with bias-corrected moment estimates to ensure stability and convergence. Featuring a computational complexity proportional to the model parameters, Adam remains efficient and scalable across diverse applications. Empirical evaluations underscore Adam's remarkable convergence rates and enhanced stability under various experimental setups, effectively outperforming state-of-the-art optimizers like stochastic gradient descent. This study not only elaborates on theoretical advancements but also demonstrates practical implementation insights and results, consolidating Adam's instrumental role in advancing scalable and efficient machine learning solutions.
+# \end{abstract}
 
-The efficacy of optimization algorithms significantly impacts the advancements in machine learning, particularly in addressing challenges such as high-dimensional parameter spaces and sparse gradients. Historically, Stochastic Gradient Descent (SGD) has been the cornerstone for optimization, but it faces limitations in scenarios involving non-stationary objectives or sparse data. Enhanced methods like AdaGrad and RMSProp were introduced to mitigate these challenges. AdaGrad achieves effective updates by normalizing the learning rates through accumulated squared gradients, benefiting sparse settings but hampered by diminishing learning rates over iterations. On the other hand, RMSProp addresses this by employing an exponentially decaying average of squared gradients, thereby preserving the learning rate stability over time.
+# \section{Introduction}
+# \label{sec:intro}
+# Adam, an acronym for Adaptive Moment Estimation, signifies a pivotal innovation in optimization methodologies within the realm of machine learning. The seminal paper \textit{Adam: A Method for Stochastic Optimization} introduces this algorithm and highlights its value in tackling complex challenges such as high-dimensional parameter spaces, stochastic objective functions, and noisy gradient calculations. Adam amalgamates concepts from momentum-based methods and adaptivity found in RMSprop, enabling dynamic adjustment of learning rates on a per-parameter basis by utilizing estimates of the first and second moments of the gradients. This approach enhances both convergence speed and stability.
 
-Building on this foundation, the Adam optimization algorithm implements adaptive moment estimation, which computes individual parameter-specific learning rates leveraging both first and second moments of the gradients. Adam also includes bias correction procedures to accommodate initialization effects, ensuring reliable convergence even in high-noise or dynamic scenarios. Empirical studies demonstrate Adam's superiority in achieving robust optimizations across diverse machine learning domains, ranging from deep neural networks to generalized optimization problems. Its mechanical innovations and performance benchmarks underscore its pivotal role in advancing modern optimization techniques in machine learning.
+# Adam is particularly adept in scenarios where conventional methods face difficulties, such as in environments characterized by sparse gradients or significant gradient noise. By minimizing dependency on manual hyperparameter tuning, the algorithm facilitates widespread applicability across varied machine learning tasks. Its simplicity in implementation, coupled with robust performance, underscores its critical role in training neural networks, where optimization processes profoundly influence model accuracy and generalization.
 
-\section{Background}
-\label{sec:background}
-\subsection{Introduction to Stochastic Optimization}
+# The publication meticulously details Adam's algorithmic mechanism, illustrating its superiority through comparative analyses against predecessors, such as AdaGrad and RMSprop. It demonstrates Adam's capabilities in not only achieving faster convergence but also in handling diversified optimization landscapes effectively. To support practical applications, the paper provides guidance on parameter initialization and offers pseudocode for seamless integration by researchers and practitioners.
 
-Stochastic optimization constitutes a significant framework within computational methodologies, particularly in the realm of machine learning applications. This approach emphasizes optimizing objective functions through iterative refinement of candidate solutions, leveraging randomized inputs or procedures. Randomized mechanisms enhance computational efficiency, especially in addressing large-scale, high-dimensional problems.
+# Moreover, the authors discuss extensibility avenues, proposing enhancements that cater to evolving demands in machine learning. This includes adjustments to ensure better stabilization and integration into sophisticated optimization frameworks. Consequently, Adam's introduction not only marks a transformative milestone but also lays the groundwork for continued exploration and refinement of optimization algorithms within the field.
 
-Gradient-based methods serve as the foundation of stochastic optimization techniques. Specifically, Stochastic Gradient Descent (SGD) gains popularity due to its procedural simplicity and effectiveness. However, SGD often encounters difficulties in scenarios involving high-dimensional parameter spaces or noisy objectives. Addressing these challenges, extensions like adaptive learning rates and momentum mechanisms have been proposed, ensuring more stable and rapid convergence.
+# To summarize the contributions of the introduced Adam optimization method:
+# \begin{itemize}
+#     \item A novel algorithm combining strengths of momentum and adaptivity for enhanced performance.
+#     \item Demonstration of superior handling of challenges in stochastic, high-dimensional optimization problems.
+#     \item Provision of practical guidance for implementation and parameter settings to benefit varied machine learning undertakings.
+#     \item Exploration of potential future developments ensuring the algorithm's sustained relevance.
+# \end{itemize}
 
-\subsection{Adaptive Learning Rate Strategies}
+# \section{Related Work}
+# \label{sec:related}
+# \subsection{Comparative Analysis of Optimization Methods}
 
-Adaptive learning rate techniques, such as AdaGrad and RMSProp, tailor individual parameter learning rates dynamically during optimization. AdaGrad adjusts learning rates based on cumulative squared gradients, accommodating sparse data scenarios. Meanwhile, RMSProp combats declining learning rates in AdaGrad by introducing an exponential decay factor, balancing step size across iterations. These methodologies play pivotal roles in overcoming optimization challenges, yet balancing convergence speed and generalization performance remains a complexity.
+# The efficacy of optimization algorithms significantly impacts the advancements in machine learning, particularly in addressing challenges such as high-dimensional parameter spaces and sparse gradients. Historically, Stochastic Gradient Descent (SGD) has been the cornerstone for optimization, but it faces limitations in scenarios involving non-stationary objectives or sparse data. Enhanced methods like AdaGrad and RMSProp were introduced to mitigate these challenges. AdaGrad achieves effective updates by normalizing the learning rates through accumulated squared gradients, benefiting sparse settings but hampered by diminishing learning rates over iterations. On the other hand, RMSProp addresses this by employing an exponentially decaying average of squared gradients, thereby preserving the learning rate stability over time.
 
-\subsection{Problem Setting}
+# Building on this foundation, the Adam optimization algorithm implements adaptive moment estimation, which computes individual parameter-specific learning rates leveraging both first and second moments of the gradients. Adam also includes bias correction procedures to accommodate initialization effects, ensuring reliable convergence even in high-noise or dynamic scenarios. Empirical studies demonstrate Adam's superiority in achieving robust optimizations across diverse machine learning domains, ranging from deep neural networks to generalized optimization problems. Its mechanical innovations and performance benchmarks underscore its pivotal role in advancing modern optimization techniques in machine learning.
 
-This study underscores the Adaptive Moment Estimation (Adam) optimizer, a strategy that integrates stochastic optimization with adaptive techniques. Adam excels in sparse and noisy gradient optimization settings, leveraging first and second moment gradient estimations to dynamically adjust learning rates, ensuring stable and efficient convergence. By amalgamating strengths from predecessors like AdaGrad and RMSProp, Adam introduces features that enhance its versatility and reliability across extensive optimization scenarios.
+# \section{Background}
+# \label{sec:background}
+# \subsection{Introduction to Stochastic Optimization}
 
-\section{Method}
-\label{sec:method}
-\subsection{Adam Algorithm Overview}
+# Stochastic optimization constitutes a significant framework within computational methodologies, particularly in the realm of machine learning applications. This approach emphasizes optimizing objective functions through iterative refinement of candidate solutions, leveraging randomized inputs or procedures. Randomized mechanisms enhance computational efficiency, especially in addressing large-scale, high-dimensional problems.
 
-The Adam optimization algorithm represents a significant advancement in stochastic optimization techniques through its adaptive moment estimation approach, which optimizes objective functions characterized by noise and complexity. Employing first- and second-order moment estimates dynamically adjusts the learning rate for each parameter. The algorithm's systematic procedure is detailed below:
+# Gradient-based methods serve as the foundation of stochastic optimization techniques. Specifically, Stochastic Gradient Descent (SGD) gains popularity due to its procedural simplicity and effectiveness. However, SGD often encounters difficulties in scenarios involving high-dimensional parameter spaces or noisy objectives. Addressing these challenges, extensions like adaptive learning rates and momentum mechanisms have been proposed, ensuring more stable and rapid convergence.
 
-\textbf{Algorithm 1: Adam}
+# \subsection{Adaptive Learning Rate Strategies}
 
-\begin{enumerate}
-    \item \textbf{Input}:
-    \begin{itemize}
-        \item Stepsize $\alpha$
-        \item Exponential decay rates $\beta_1, \beta_2 \in [0, 1)$
-        \item Small constant $\epsilon$
-    \end{itemize}
-    \item Initialize $m_0 \leftarrow 0$, $v_0 \leftarrow 0$, $t \leftarrow 0$
-    \item Repeat until convergence:
-    \begin{enumerate}
-        \item $t \leftarrow t + 1$
-        \item Compute gradients: $g_t \leftarrow \nabla_{\theta} f_t(\theta_{t-1})$
-        \item Update biased moment estimates:\newline
-        $m_t \leftarrow \beta_1 \cdot m_{t-1} + (1 - \beta_1) \cdot g_t$
-        $v_t \leftarrow \beta_2 \cdot v_{t-1} + (1 - \beta_2) \cdot g_t^2$
-        \item Compute bias-corrected estimates:\newline
-        $\hat{m}_t \leftarrow \frac{m_t}{1-\beta_1^t}$
-        $\hat{v}_t \leftarrow \frac{v_t}{1-\beta_2^t}$
-        \item Update parameters:\newline
-        $\theta_t \leftarrow \theta_{t-1} - \frac{\alpha \cdot \hat{m}_t}{\sqrt{\hat{v}_t} + \epsilon}$
-    \end{enumerate}
-    \item \textbf{Output}: Updated parameters $\theta_t$
-\end{enumerate}
+# Adaptive learning rate techniques, such as AdaGrad and RMSProp, tailor individual parameter learning rates dynamically during optimization. AdaGrad adjusts learning rates based on cumulative squared gradients, accommodating sparse data scenarios. Meanwhile, RMSProp combats declining learning rates in AdaGrad by introducing an exponential decay factor, balancing step size across iterations. These methodologies play pivotal roles in overcoming optimization challenges, yet balancing convergence speed and generalization performance remains a complexity.
 
-\subsection{Computational Efficiency and Robustness}
+# \subsection{Problem Setting}
 
-The Adam algorithm's computational complexity per iteration is $O(d)$, where $d$ denotes the number of parameters. Its design ensures constant update consistency across varying gradient magnitudes. Empirical studies demonstrate its superiority in scenarios with substantial stochasticity, including non-stationary objectives. Through rigorous testing, the algorithm exhibits notable advantages in convergence speed and stability over comparable methods like AdaGrad and RMSProp, establishing its effectiveness and versatility.
+# This study underscores the Adaptive Moment Estimation (Adam) optimizer, a strategy that integrates stochastic optimization with adaptive techniques. Adam excels in sparse and noisy gradient optimization settings, leveraging first and second moment gradient estimations to dynamically adjust learning rates, ensuring stable and efficient convergence. By amalgamating strengths from predecessors like AdaGrad and RMSProp, Adam introduces features that enhance its versatility and reliability across extensive optimization scenarios.
 
-\subsection{Comparison with Other Methods}
+# \section{Method}
+# \label{sec:method}
+# \subsection{Adam Algorithm Overview}
 
-Extensive ablation studies underline Adam's distinctive performance attributes under diverse conditions. While AdaGrad may underperform in sparse gradient situations, Adam consistently maintains effectiveness across a broader spectrum. This distinction affirms Adam's role as a robust optimization solution for modern machine learning applications. Hyperparameter analysis highlights the critical role of bias correction in preserving algorithmic stability, corroborating its efficacy in optimizing challenging landscapes.
+# The Adam optimization algorithm represents a significant advancement in stochastic optimization techniques through its adaptive moment estimation approach, which optimizes objective functions characterized by noise and complexity. Employing first- and second-order moment estimates dynamically adjusts the learning rate for each parameter. The algorithm's systematic procedure is detailed below:
 
-Through its comprehensive design and rigorous demonstration, the Adam algorithm underscores its pivotal contribution to scalable machine learning, establishing benchmarks for optimization algorithms in theoretical and practical contexts.
+# \textbf{Algorithm 1: Adam}
 
-\section{Experimental Setup}
-\label{sec:experimental}
-\subsection{Dataset Description}
+# \begin{enumerate}
+#     \item \textbf{Input}:
+#     \begin{itemize}
+#         \item Stepsize $\alpha$
+#         \item Exponential decay rates $\beta_1, \beta_2 \in [0, 1)$
+#         \item Small constant $\epsilon$
+#     \end{itemize}
+#     \item Initialize $m_0 \leftarrow 0$, $v_0 \leftarrow 0$, $t \leftarrow 0$
+#     \item Repeat until convergence:
+#     \begin{enumerate}
+#         \item $t \leftarrow t + 1$
+#         \item Compute gradients: $g_t \leftarrow \nabla_{\theta} f_t(\theta_{t-1})$
+#         \item Update biased moment estimates:\newline
+#         $m_t \leftarrow \beta_1 \cdot m_{t-1} + (1 - \beta_1) \cdot g_t$
+#         $v_t \leftarrow \beta_2 \cdot v_{t-1} + (1 - \beta_2) \cdot g_t^2$
+#         \item Compute bias-corrected estimates:\newline
+#         $\hat{m}_t \leftarrow \frac{m_t}{1-\beta_1^t}$
+#         $\hat{v}_t \leftarrow \frac{v_t}{1-\beta_2^t}$
+#         \item Update parameters:\newline
+#         $\theta_t \leftarrow \theta_{t-1} - \frac{\alpha \cdot \hat{m}_t}{\sqrt{\hat{v}_t} + \epsilon}$
+#     \end{enumerate}
+#     \item \textbf{Output}: Updated parameters $\theta_t$
+# \end{enumerate}
 
-In evaluating the proposed Adam optimization method, diverse datasets were utilized to ensure a comprehensive validation. These comprised synthetic datasets tailored to simulate scenarios such as high-dimensional parameter spaces, noisy gradients, and sparse gradient distributions. Additionally, real-world datasets were carefully selected from established machine learning benchmarks to further substantiate the efficacy across a wide array of practical situations. The combination of these datasets provided a robust platform to highlight Adam's performance.
+# \subsection{Computational Efficiency and Robustness}
 
-\subsection{Initialization and Parameter Configuration}
+# The Adam algorithm's computational complexity per iteration is $O(d)$, where $d$ denotes the number of parameters. Its design ensures constant update consistency across varying gradient magnitudes. Empirical studies demonstrate its superiority in scenarios with substantial stochasticity, including non-stationary objectives. Through rigorous testing, the algorithm exhibits notable advantages in convergence speed and stability over comparable methods like AdaGrad and RMSProp, establishing its effectiveness and versatility.
 
-To guarantee an unbiased comparison, uniform initialization schemes aligned with standard practices in optimization algorithms were applied. Key hyperparameter settings for Adam were established as follows: the learning rate \( \alpha = 0.001 \), exponential decay factors \( \beta_1 = 0.9 \) for the first moment and \( \beta_2 = 0.999 \) for the second moment, and the stability constant \( \epsilon = 10^{-8} \). These values reflect commonly recommended defaults for general-purpose optimization tasks. Comparative baseline algorithms were configured according to their respective standard parameterization.
+# \subsection{Comparison with Other Methods}
 
-\subsection{Baseline Methods}
+# Extensive ablation studies underline Adam's distinctive performance attributes under diverse conditions. While AdaGrad may underperform in sparse gradient situations, Adam consistently maintains effectiveness across a broader spectrum. This distinction affirms Adam's role as a robust optimization solution for modern machine learning applications. Hyperparameter analysis highlights the critical role of bias correction in preserving algorithmic stability, corroborating its efficacy in optimizing challenging landscapes.
 
-The study included several baseline optimization methods for comparison, encompassing Stochastic Gradient Descent (SGD), AdaGrad, and RMSProp. Their configurations adhered to published and widely accepted guidelines. This ensured a fair evaluation of convergence behavior, precision, and efficiency metrics across equivalent experimental setups.
+# Through its comprehensive design and rigorous demonstration, the Adam algorithm underscores its pivotal contribution to scalable machine learning, establishing benchmarks for optimization algorithms in theoretical and practical contexts.
 
-\subsection{Evaluation Metrics}
+# \section{Experimental Setup}
+# \label{sec:experimental}
+# \subsection{Dataset Description}
 
-Quantitative evaluation of the optimization methods employed metrics such as convergence rate, final solution accuracy, and computational efficiency. The convergence rate was assessed by determining the number of iterations needed to reach a specified threshold in loss reduction. Final solution accuracy involved comparison of the ultimate objective value achieved, while computational efficiency considered elapsed time on identical computational environments to account for runtime differences.
+# In evaluating the proposed Adam optimization method, diverse datasets were utilized to ensure a comprehensive validation. These comprised synthetic datasets tailored to simulate scenarios such as high-dimensional parameter spaces, noisy gradients, and sparse gradient distributions. Additionally, real-world datasets were carefully selected from established machine learning benchmarks to further substantiate the efficacy across a wide array of practical situations. The combination of these datasets provided a robust platform to highlight Adam's performance.
 
-\begin{figure}[t]
-    \centering
-    \begin{subfigure}{0.9\textwidth}
-        \includegraphics[width=\textwidth]{generated_images.png}
-        \label{fig:diffusion-samples}
-    \end{subfigure}
-    \caption{PLEASE FILL IN CAPTION HERE}
-    \label{fig:first_figure}
-\end{figure}
+# \subsection{Initialization and Parameter Configuration}
 
-\section{Results}
-\label{sec:results}
-\subsection{Performance Evaluation and Analyses}
+# To guarantee an unbiased comparison, uniform initialization schemes aligned with standard practices in optimization algorithms were applied. Key hyperparameter settings for Adam were established as follows: the learning rate \( \alpha = 0.001 \), exponential decay factors \( \beta_1 = 0.9 \) for the first moment and \( \beta_2 = 0.999 \) for the second moment, and the stability constant \( \epsilon = 10^{-8} \). These values reflect commonly recommended defaults for general-purpose optimization tasks. Comparative baseline algorithms were configured according to their respective standard parameterization.
 
-\subsubsection{Classification Tasks}
+# \subsection{Baseline Methods}
 
-The Adam optimizer's efficacy was benchmarked on the MNIST dataset, utilized for image classification tasks. Table \ref{tab:mnist_stats} delineates the test accuracies and corresponding convergence times for Adam relative to other optimizers. The experiments were configured with a learning rate of $0.001$ and run over $50$ epochs. Adam demonstrated enhanced accuracy and expedited convergence, confirming its robustness in addressing high-dimensional parameter spaces.
+# The study included several baseline optimization methods for comparison, encompassing Stochastic Gradient Descent (SGD), AdaGrad, and RMSProp. Their configurations adhered to published and widely accepted guidelines. This ensured a fair evaluation of convergence behavior, precision, and efficiency metrics across equivalent experimental setups.
 
-\begin{table}[h!]
-\centering
-\caption{Test accuracy and convergence time comparison on the MNIST dataset. Adam denotes clear advantages in performance metrics.}
-\label{tab:mnist_stats}
-\begin{tabular}{|l|c|c|}
-\hline
-\textbf{Optimizer} & \textbf{Test Accuracy} & \textbf{Convergence Time (s)} \\
-\hline
-SGD & $98.0\%$ & $250$ \\
-AdaGrad & $98.2\%$ & $230$ \\
-RMSProp & $98.3\%$ & $220$ \\
-Adam & $\mathbf{98.5\%}$ & $\mathbf{200}$ \\
-\hline
-\end{tabular}
-\end{table}
+# \subsection{Evaluation Metrics}
 
-\subsubsection{Hyperparameter Sensitivity}
+# Quantitative evaluation of the optimization methods employed metrics such as convergence rate, final solution accuracy, and computational efficiency. The convergence rate was assessed by determining the number of iterations needed to reach a specified threshold in loss reduction. Final solution accuracy involved comparison of the ultimate objective value achieved, while computational efficiency considered elapsed time on identical computational environments to account for runtime differences.
 
-Extensive studies revealed Adam's capacity to maintain optimal performance across varying hyperparameter ($\beta_1$, $\beta_2$) values. Figure \ref{fig:hypersensitivity} visualizes the influence of these variations, affirming Adam's tolerance to fluctuating configurations.
+# \begin{figure}[t]
+#     \centering
+#     \begin{subfigure}{0.9\textwidth}
+#         \includegraphics[width=\textwidth]{generated_images.png}
+#         \label{fig:diffusion-samples}
+#     \end{subfigure}
+#     \caption{PLEASE FILL IN CAPTION HERE}
+#     \label{fig:first_figure}
+# \end{figure}
 
-\begin{figure}[h!]
-\centering
-\includegraphics[width=0.75\linewidth]{hyperparam_sensitivity.png}
-\caption{Outcomes of sensitivity analyses on Adam's hyperparameters. Performance consistently remains proficient over operative ranges.}
-\label{fig:hypersensitivity}
-\end{figure}
+# \section{Results}
+# \label{sec:results}
+# \subsection{Performance Evaluation and Analyses}
 
-\subsubsection{Challenges and Prospective Improvements}
+# \subsubsection{Classification Tasks}
 
-Despite its advantages, Adam may exhibit limitations in stochastic environments characterized by high noise amplitudes. Further explorations into gradient correction techniques and variance reduction mechanisms appear promising for overcoming these challenges, potentially broadening its applicability.
+# The Adam optimizer's efficacy was benchmarked on the MNIST dataset, utilized for image classification tasks. Table \ref{tab:mnist_stats} delineates the test accuracies and corresponding convergence times for Adam relative to other optimizers. The experiments were configured with a learning rate of $0.001$ and run over $50$ epochs. Adam demonstrated enhanced accuracy and expedited convergence, confirming its robustness in addressing high-dimensional parameter spaces.
 
-\section{Conclusions and Future Work}
-\label{sec:conclusion}
-The Adam optimization algorithm represents a transformative development in the field of stochastic optimization approaches. By incorporating adaptive moment estimation of gradients' first and second moments, Adam dynamically adjusts learning rates per parameter, addressing common issues such as sparse and noisy gradients in non-stationary and high-dimensional datasets. This research highlights the theoretical underpinnings and operational mechanics of Adam, affirming its significant advancements over established methodologies like AdaGrad and RMSProp. Experimental demonstration of Adam's improved convergence properties further supports its robustness and versatility in neural network training and beyond. Insights gained suggest promising avenues for future exploration, including integrating higher-order moments, exploring hybrid optimization models, and refining domain-specific parameter tuning, to further enhance the algorithm's efficacy. Such developments are poised to enrich optimization theories, fostering the algorithm's adaptability to the evolving landscapes of machine learning applications. Consequently, Adam's contributions underscore its critical role as a foundational algorithm driving continuous progress in computational methodologies.
+# \begin{table}[h!]
+# \centering
+# \caption{Test accuracy and convergence time comparison on the MNIST dataset. Adam denotes clear advantages in performance metrics.}
+# \label{tab:mnist_stats}
+# \begin{tabular}{|l|c|c|}
+# \hline
+# \textbf{Optimizer} & \textbf{Test Accuracy} & \textbf{Convergence Time (s)} \\
+# \hline
+# SGD & $98.0\%$ & $250$ \\
+# AdaGrad & $98.2\%$ & $230$ \\
+# RMSProp & $98.3\%$ & $220$ \\
+# Adam & $\mathbf{98.5\%}$ & $\mathbf{200}$ \\
+# \hline
+# \end{tabular}
+# \end{table}
 
-This work was generated by \textsc{The AI Scientist} \citep{lu2024aiscientist}.
+# \subsubsection{Hyperparameter Sensitivity}
 
-\bibliographystyle{iclr2024_conference}
-\bibliography{references}
+# Extensive studies revealed Adam's capacity to maintain optimal performance across varying hyperparameter ($\beta_1$, $\beta_2$) values. Figure \ref{fig:hypersensitivity} visualizes the influence of these variations, affirming Adam's tolerance to fluctuating configurations.
 
-\end{document}
-"""
-}
+# \begin{figure}[h!]
+# \centering
+# \includegraphics[width=0.75\linewidth]{hyperparam_sensitivity.png}
+# \caption{Outcomes of sensitivity analyses on Adam's hyperparameters. Performance consistently remains proficient over operative ranges.}
+# \label{fig:hypersensitivity}
+# \end{figure}
+
+# \subsubsection{Challenges and Prospective Improvements}
+
+# Despite its advantages, Adam may exhibit limitations in stochastic environments characterized by high noise amplitudes. Further explorations into gradient correction techniques and variance reduction mechanisms appear promising for overcoming these challenges, potentially broadening its applicability.
+
+# \section{Conclusions and Future Work}
+# \label{sec:conclusion}
+# The Adam optimization algorithm represents a transformative development in the field of stochastic optimization approaches. By incorporating adaptive moment estimation of gradients' first and second moments, Adam dynamically adjusts learning rates per parameter, addressing common issues such as sparse and noisy gradients in non-stationary and high-dimensional datasets. This research highlights the theoretical underpinnings and operational mechanics of Adam, affirming its significant advancements over established methodologies like AdaGrad and RMSProp. Experimental demonstration of Adam's improved convergence properties further supports its robustness and versatility in neural network training and beyond. Insights gained suggest promising avenues for future exploration, including integrating higher-order moments, exploring hybrid optimization models, and refining domain-specific parameter tuning, to further enhance the algorithm's efficacy. Such developments are poised to enrich optimization theories, fostering the algorithm's adaptability to the evolving landscapes of machine learning applications. Consequently, Adam's contributions underscore its critical role as a foundational algorithm driving continuous progress in computational methodologies.
+
+# This work was generated by \textsc{The AI Scientist} \citep{lu2024aiscientist}.
+
+# \bibliographystyle{iclr2024_conference}
+# \bibliography{references}
+
+# \end{document}
+# """

--- a/src/researchgraph/review_subgraph/nodes/review_node.py
+++ b/src/researchgraph/review_subgraph/nodes/review_node.py
@@ -9,16 +9,36 @@ from typing import Optional
 
 
 # 各サブグラフの出力フィールドを定義
-SUBGRAPH_OUTPUT_FIELDS = {
+LLM_OUTPUT_FIELDS = {
     "retrieve_paper_subgraph": {},
-    "generate_subgraph": {},
-    "executor_subgraph": {},
-    "writer_subgraph": {
+    "generator_subgraph": {},
+    "executor_subgraph": {
+        "review_score_correctness": (float, ...),
+        "review_score_novelty": (float, ...),
+        "review_score_reproducibility": (float, ...),
         "review_feedback": (str, ...),
+        "llm_return_to": (str, ...), 
+    },
+    "writer_subgraph": {
         "review_score_clarity": (float, ...),
         "review_score_structure": (float, ...),
         "review_score_technical_depth": (float, ...),
+        "review_feedback": (str, ...),
+        "llm_return_to": (str, ...), 
     },
+}
+
+REVIEW_ROUTING_RULES = {
+    "retrieve_paper_subgraph": {}, 
+    "generator_subgraph": {}, 
+    "executor_subgraph": {"generator_subgraph"}, 
+    "writer_subgraph": {}, 
+}
+
+SUBGRAPH_OUTPUTS_KEYS = {
+    "generator_subgraph": ["verification_policy", "experiment_detail", "experiment_code"],
+    "executor_subgraph": ["output_text_data"],
+    "writer_subgraph": ["tex_text"]
 }
 
 class DynamicModel(BaseModel):
@@ -37,6 +57,7 @@ class ReviewNode:
         self.save_dir = save_dir
         self.review_target = review_target
         self.threshold = threshold
+
         self.env = Environment()
         self.dynamic_model = self._create_dynamic_model(DynamicModel)
 
@@ -45,26 +66,51 @@ class ReviewNode:
         Your task is to evaluate research papers critically, identifying strengths and weaknesses, and suggesting improvements. 
         Your feedback should be constructive, specific, and actionable.
 
-        **Instructions:**
+        **Pipeline Overview:**
+        This system is an **automated research system** that combines existing papers to generate novel methodologies. 
+
+        1. **retrieve_paper_subgraph**
+            - Role: Retrieve base papers and patch papers as materials for generating a new methodology.
+
+        2. **generator_subgraph**
+            - Role: Synthesize a new methodology by combining elements from the retrieved papers.
+
+        3. **executor_subgraph**
+            - Role: Implement and execute the newly synthesized methodology through coding.
+
+        4. **writer_subgraph**
+            - Role: Use the synthesized methodology and execution results to generate a research paper, embedding it in LaTeX format.
+
+        **Evaluation Criteria and Scoring:**
         1. Rate each evaluation criterion on a scale of 1.0 to 5.0, with increments of 0.1:
             - 1.0～2.0 = Needs significant improvement
             - 2.1～3.0 = Below average
             - 3.1～4.0 = Acceptable with revisions
             - 4.1～5.0 = High quality
 
-        **Be conservative in awarding high scores**  
-        For a 5.0 rating, the paper or idea should demonstrate exceptional clarity, originality, methodology, and significance with virtually no major flaws.
+            **Be conservative in awarding high scores**  
+            A **5.0 rating** should be given only if the paper demonstrates **exceptional clarity, originality, methodology, and significance** with virtually no major flaws.
 
         2. For each criterion you score:
             - **Provide specific evidence** from the text or proposal to justify the score. 
             - Clearly explain how that evidence supports the numeric rating. 
             - Include **direct references (e.g., “In Section 3, the method is vaguely described...”)** or excerpts to pinpoint strong or weak points.
     
-        3. **Identify at least three specific areas for improvement** and provide **clear revision suggestions in the `review_feedback` field**:
+        **Feedback and Suggested Improvement:**
+        1. **Identify at least three specific areas for improvement** and provide **clear revision suggestions in the `review_feedback` field**:
             - **What aspects contributed to this score?**
             - **What needs to be changed?**
             - **How should it be revised?**
             - **Why will this improve the paper?**
+
+        **Routing Rules*:*
+        1. If the paper requires further work, suggest revisiting an earlier subgraph or re-running the current subgraph.
+            - **Do not route to any subgraph that comes AFTER the current one in the pipeline.**
+
+        2. Additional custom restrictions:
+            - The `{{ REVIEW_ROUTING_RULES }}` dictionary defines specific routing constraints. The **keys represent the review criteria**, and the **values represent possible routing destinations** for revisions.
+            - If the value is empty (`[]`), there are no additional restrictions, but **only previous subgraphs in the pipeline can be revisited** (i.e., the process cannot move forward past its current stage).
+
 
         **Output Format:**
         Your response must be in the following JSON format:
@@ -73,6 +119,7 @@ class ReviewNode:
         "review_score_yyy": <1.0-5.0>, 
         "review_score_zzz": <1.0-5.0>, 
         "review_feedback": "<Your feedback here>" 
+        "llm_return_to": "<subgraph_name to be re-executed>"
         }   
         """
 
@@ -80,10 +127,21 @@ class ReviewNode:
             "retrieve_paper_subgraph": """
             """,
             
-            "generate_subgraph": """
+            "generator_subgraph": """
             """,
             
             "executor_subgraph": """
+            Evaluate the experimental implementation and execution based on the following criteria:
+
+            **Evaluation Criteria:**
+            - **review_score_correctness (1.0-5.0)**: Does the implementation correctly execute the intended methodology? Are the results consistent with expectations?
+            - **review_score_novelty (1.0-5.0)**: Does the implementation introduce novel experimental techniques, optimizations, or unique approaches?
+            - **review_score_reproducibility (1.0-5.0)**: Can the implementation be easily replicated by other researchers based on the provided information?
+            - **review_feedback**: Provide feedback on the strengths and weaknesses of the implementation and suggest improvements.
+            - **llm_return_to**: "<subgraph_name to be re-executed>"
+
+            **Review Content（JSON）:**
+            {{ content }}
             """,
             
             "writer_subgraph": """
@@ -94,36 +152,63 @@ class ReviewNode:
             - **review_score_structure (1.0-5.0)**: Is the structure and organization of the paper logical and coherent?
             - **review_score_technical_depth (1.0-5.0)**: Does the paper provide sufficient technical depth and explanation?
             - **review_feedback**: Provide feedback on the strengths and weaknesses of the paper and suggest improvements.
+            - **llm_return_to**:  "<subgraph_name to be re-executed>"
 
-            **Research Paper Content (LaTeX format):**
+            **Review Content（JSON）:**
             {{ content }}
             """
         }
 
     def _create_dynamic_model(self, base_model: BaseModel) -> BaseModel:
         """ review_target に応じた動的な Pydantic モデルを生成する """
-        fields = SUBGRAPH_OUTPUT_FIELDS.get(self.review_target, {})
+        fields = LLM_OUTPUT_FIELDS.get(self.review_target, {})
         return create_model(
             f"LLMOutput_{self.review_target.capitalize()}",
             **fields,
             __base__=base_model,
         )
+    
+    def _construct_review_content(self, state: dict) -> str:
+        current_subgraph = self.review_target
+        current_output = {
+            key: state.get(key, "<missing_data>")
+            for key in SUBGRAPH_OUTPUTS_KEYS.get(current_subgraph, [])
+        }
 
-    def _review(self, content: str) -> Optional[tuple[str, dict]]:
+        previous_subgraph_outputs = {}
+
+        for subgraph_name, keys in SUBGRAPH_OUTPUTS_KEYS.items():
+            if subgraph_name == current_subgraph:
+                break
+            subgraph_data = {
+                key: state.get(key, "<missing_data>")
+                for key in keys
+            }
+            previous_subgraph_outputs[subgraph_name] = subgraph_data
+
+        review_content = {
+            "current_subgraph": current_subgraph, 
+            "current_output": current_output, 
+            "previous_subgraph_outputs": previous_subgraph_outputs, 
+        }
+
+        return json.dumps(review_content, indent=2)
+
+    def _review(self, content: str) -> Optional[tuple[str, dict, str]]:
 
         if self.review_target not in self.review_prompt_dict:
             raise ValueError(f"Invalid review target: {self.review_target}")
 
-        template = self.env.from_string(self.review_prompt_dict[self.review_target])
-        prompt = template.render({"content": content})
+        system_prompt_rendered = self.env.from_string(self.review_system_prompt).render({"REVIEW_ROUTING_RULES": REVIEW_ROUTING_RULES})
+        user_prompt_rendered = self.env.from_string(self.review_prompt_dict[self.review_target]).render({"content": content})
         max_retries = 3
         for attempt in range(max_retries): 
             try:
                 response = completion(
                     model=self.llm_name,
                     messages=[
-                        {"role": "system", "content": self.review_system_prompt},
-                        {"role": "user", "content": prompt},
+                        {"role": "system", "content": system_prompt_rendered},
+                        {"role": "user", "content": user_prompt_rendered},
                     ],
                     temperature=0,
                     response_format=self.dynamic_model,
@@ -134,30 +219,55 @@ class ReviewNode:
                     key: value for key, value in structured_output.items()
                     if key.startswith("review_score_") and isinstance(value, float)
                 }
-                return review_feedback, review_scores
+                llm_return_to = structured_output.get("llm_return_to", None)
+                return review_feedback, review_scores, llm_return_to
 
             except Exception as e:
                 print(f"[Attempt {attempt+1}/{max_retries}] Unexpected error: {e}")
         print("Exceeded maximum retries for LLM call.")
         return None
 
-    def _review_judgement(self, review_scores: dict) -> bool:
-        return all(score >= self.threshold for score in review_scores.values())
-    
-    def _save_review_log(self, content: str, review_decision: bool, review_scores: dict, review_feedback: str): 
-        #TODO: 同じワークフロー内で生成されるレビューを1つのファイルに集約できるようにする
+    def _review_judgement(self, review_scores: dict, llm_return_to: str) -> Optional[str]:
+        # 1) すべてのスコアが threshold 以上なら合格 → return None（= 次に進む）
+        if all(score >= self.threshold for score in review_scores.values()):
+            return None
+        
+        # 2) llm_return_to の値が想定外ならフォールバック
+        valid_subgraphs = set(LLM_OUTPUT_FIELDS.keys())
+        if llm_return_to not in valid_subgraphs:
+            print(f"Warning: Unexpected llm_return_to value '{llm_return_to}', defaulting to '{self.review_target}'")
+            return self.review_target
+        
+        # 3) REVIEW_ROUTING_RULES による制限を適用する
+        allowed_routes = REVIEW_ROUTING_RULES.get(self.review_target, set())
+        if allowed_routes and llm_return_to not in allowed_routes:
+            print(f"Warning: subgraph '{self.review_target}' can only route to {allowed_routes}, "
+                f"but got '{llm_return_to}', Fallback to '{self.review_target}'")
+            return self.review_target
+        
+        return llm_return_to
+                
+    def _save_review_log(self, review_routing: Optional[str], review_scores: dict, review_feedback: str, content: str): 
+        #TODO: 同じワークフロー内で生成されるレビューを1つのファイルに集約できるようにする。
 
         os.makedirs(self.save_dir, exist_ok=True)
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         review_file = osp.join(self.save_dir, f"{timestamp}_review.json")
+
+        try:
+            review_content = json.loads(content)
+        except json.JSONDecodeError as e:
+            print(f"JSON decode error: {e}")
+            review_content = {"raw_content": content}
+
         review_data = {
             "timestamp": timestamp,
             "review_target": self.review_target,
-            "review_decision": "Accepted" if review_decision else "Needs Improvement",
+            "review_routing": "Pass" if review_routing is None else review_routing,  
             "review_scores": review_scores,
             "review_feedback": review_feedback,
-            "content": content, 
+            "content": review_content, 
         }
         try:
             with open(review_file, "w") as f:
@@ -166,14 +276,22 @@ class ReviewNode:
         except Exception as e:
             print(f"Failed to save review log: {e}")
 
-    def execute(self, content: str) -> tuple[bool, str]:
+    def execute(self, state: dict) -> tuple[Optional[str], str]:
+        current_output_keys = SUBGRAPH_OUTPUTS_KEYS.get(self.review_target, [])
+        if any(state.get(key) is None for key in current_output_keys):
+            print(f"Skipping review: Missing data for {self.review_target}")
+            return None, "Skipped review due to missing data."
+
+        content = self._construct_review_content(state)
+        print(f"content: {content}")
+
         print("Reviewing content...")
         review_result = self._review(content)
         if not review_result:
             raise RuntimeError("Failed to review content. The LLM returned an empty response.")
 
-        review_feedback, review_scores = review_result
-        review_decision = self._review_judgement(review_scores)
-        self._save_review_log(content, review_decision, review_scores, review_feedback)
+        review_feedback, review_scores, llm_return_to = review_result
+        review_routing = self._review_judgement(review_scores, llm_return_to)
+        self._save_review_log(review_routing, review_scores, review_feedback, content)
         
-        return review_decision, review_feedback
+        return review_routing, review_feedback


### PR DESCRIPTION
# Background & Purpose
- 現在の査読モジュールでは, `execute()`がルーティング結果を`bool`で返しています. 更なる柔軟性のため, ルーティングロジックを導入し, 再実行させるサブグラフ名を返すように変更しました.
- また, ルーティング先を制限できる仕組みを追加しました. （例: `executor_subgraph` -> `generator_subgraph`のみ許可等）

# Changes
The following features have been modified:
1. `ReviewNode:` ルーティングロジックを適用し, 査読対象のサブグラフ以外にもフィードバックループを回せるようにしました. 

Details of the implementation are described below:

<details>
<summary><code>1. researchgraph/review_subgraph/nodes/review_node.py</code></summary>

 **Implementation Overview**

- **`execute()`のワークフロー:**
  1. 入力の検証: 事前に定義した`SUBGRAPH_OUTPUTS_KEY`を基に, 査読対象の`state`が渡されているか確認. 
  2. データ準備: `_construct_review_content()`を実行し, 査読LLMに渡すデータを整理. 
  3. 査読処理: `_review()`を実行し, フィードバック・スコア・ルーティング先候補を取得.  
  4. ルーティング決定:  `_review_judgement()`を実行し, スコアや制限に基づいてルーティング先を決定. 
  5. ログ保存: `_save_review_log()`を実行し, 査読結果を記録. 

- **Key Methods:**
  - `review_system_prompt`にパイプライン全体の情報と`REVIEW_ROUTING_RULES`を追加し, LLMが適切なルーティングを判断できるように修正. 
  - `_construct_review_content()`を新規実装し, 査読データの整理を明確化. 査読対象以前のサブグラフについての`state`データも取得しています. 
  - `_review_judgement()`の修正: LLMが想定外のルーティングを提案した場合に, デフォルトで査読対象モジュールにルーティングするように変更. 

- **主要なグローバル変数**
  - `LLM_OUTPUT_FIELDS:` LLMの構造化出力のマッピング. 
  - `REVIEW_ROUTING_RULES:` ルーティング先の制限（空`{}`の場合は制限なし）. 
  - `SUBGRAPH_OUTPUTS_KEYS:` `state`から必要なデータを抽出するためのマッピング.
</details>
