### PR TITLE
Add: WrapperGraph that gives each subgraph the feature to download an…

### DIFF
--- a/src/researchgraph/github_utils/github_file_io.py
+++ b/src/researchgraph/github_utils/github_file_io.py
@@ -1,0 +1,104 @@
+import os
+import base64
+import json
+import logging
+from typing import Any
+from researchgraph.utils.api_request_handler import fetch_api_data, retry_request
+
+logger = logging.getLogger(__name__)
+
+GITHUB_TOKEN = os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")
+
+
+def _build_headers():
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _download_file_from_github(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    repository_path: str,
+) -> bytes | None:
+    url = f"https://api.github.com/repos/{github_owner}/{repository_name}/contents/{repository_path}"
+    params = {"ref": branch_name}
+    response = retry_request(fetch_api_data, url, headers=_build_headers(), params=params, method="GET")
+    if response and "content" in response:
+        return base64.b64decode(response["content"])
+    return None
+
+
+def _upload_file_to_github(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    repository_path: str,
+    file_content: bytes,
+    commit_message: str = "Upload file via ResearchGraph",
+) -> bool:
+    url = f"https://api.github.com/repos/{github_owner}/{repository_name}/contents/{repository_path}"
+    existing = retry_request(fetch_api_data, url, headers=_build_headers(), params={"ref": branch_name}, method="GET")
+    sha = existing["sha"] if existing and "sha" in existing else None
+
+    data = {
+        "message": commit_message,
+        "branch": branch_name,
+        "content": base64.b64encode(file_content).decode("utf-8"),
+    }
+    if sha:
+        data["sha"] = sha
+
+    retry_request(fetch_api_data, url, headers=_build_headers(), data=data, method="PUT")
+    return True
+
+
+def github_input_node(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    input_paths: dict[str, str],
+) -> dict[str, Any]:
+    input_data = {}
+    for state_key, github_path in input_paths.items():
+        logger.info(f"[GitHub I/O] Downloading input from: {github_path}")
+        file_bytes = _download_file_from_github(
+            github_owner, repository_name, branch_name, github_path
+        )
+        if not file_bytes:
+            logger.error(f"GitHub file not found: {github_path}")
+            raise FileNotFoundError(f"Required GitHub input not found: {github_path}")
+        try:
+            input_data[state_key] = json.loads(file_bytes.decode("utf-8"))
+        except Exception as e:
+            logger.warning(f"Could not parse {github_path} as JSON. Using raw string. Error: {e}")
+            try:
+                input_data[state_key] = file_bytes.decode("utf-8") 
+            except Exception as e2:
+                logger.error(f"Failed to decode {github_path} as UTF-8 string: {e2}")
+                raise ValueError(f"Failed to decode content of {github_path}")
+    return input_data
+
+
+def github_output_node(
+    github_owner: str,
+    repository_name: str,
+    branch_name: str,
+    output_paths: dict[str, str],
+    state: dict[str, Any],
+) -> bool:
+    completion = True
+    for state_key, github_path in output_paths.items():
+        logger.info(f"[GitHub I/O] Uploading {state_key} to: {github_path}")
+        try:
+            output_bytes = json.dumps(state[state_key], indent=2, ensure_ascii=False).encode("utf-8")
+            _upload_file_to_github(
+                github_owner, repository_name, branch_name, github_path, output_bytes
+            )
+        except Exception as e:
+            logger.warning(f"Failed to upload {state_key} to {github_path}: {e}", exc_info=True)
+            completion = False
+    return completion

--- a/src/researchgraph/github_utils/graph_wrapper.py
+++ b/src/researchgraph/github_utils/graph_wrapper.py
@@ -10,46 +10,56 @@ class GraphWrapper:
         subgraph: CompiledGraph,
         github_owner: str,
         repository_name: str,
-        branch_name: str,
-        input_paths: dict[str, str],
-        output_paths: dict[str, str],
+        input_branch_name: str | None = None, 
+        input_paths: dict[str, str] | None = None,
+        output_branch_name: str | None = None,
+        output_paths: dict[str, str] | None = None,
     ):
         self.subgraph = subgraph
         self.github_owner = github_owner
         self.repository_name = repository_name
-        self.branch_name = branch_name
+        self.input_branch_name = input_branch_name
         self.input_paths = input_paths
+        self.output_branch_name = output_branch_name
         self.output_paths = output_paths
 
     @time_node("wrapper", "github_input_node")
-    def _github_input_node(self, state: dict) -> dict[str, Any]:
+    def _github_input_node(self, state: dict[str, Any]) -> dict[str, Any]:
         return github_input_node(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
-            branch_name=self.branch_name,
+            branch_name=self.input_branch_name,
             input_paths=self.input_paths,
         )
 
     @time_node("wrapper", "github_output_node")
-    def _github_output_node(self, state: dict) -> dict[str, bool]:
+    def _github_output_node(self, state: dict[str, Any]) -> dict[str, bool]:
         result = github_output_node(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
-            branch_name=self.branch_name,
+            branch_name=self.output_branch_name,
             output_paths=self.output_paths,
             state=state,
         )
         return {"github_upload_success": result}
 
     def build_graph(self) -> CompiledGraph:
-        wrapper = StateGraph(dict)
-        wrapper.add_node("github_input_node", self._github_input_node)
-        wrapper.add_node("run_subgraph", self.subgraph)
-        wrapper.add_node("github_output_node", self._github_output_node)
-        
-        wrapper.add_edge(START, "github_input_node")
-        wrapper.add_edge("github_input_node", "run_subgraph")
-        wrapper.add_edge("run_subgraph", "github_output_node")
-        wrapper.add_edge("github_output_node", END)
+        wrapper = StateGraph(dict[str, Any])
+        prev = START
 
+        if self.input_paths and self.input_branch_name:
+            wrapper.add_node("github_input_node", self._github_input_node)
+            wrapper.add_edge(prev, "github_input_node")
+            prev = "github_input_node"
+
+        wrapper.add_node("run_subgraph", self.subgraph)
+        wrapper.add_edge(prev, "run_subgraph")
+        prev = "run_subgraph"
+
+        if self.output_paths and self.output_branch_name:
+            wrapper.add_node("github_output_node", self._github_output_node)
+            wrapper.add_edge(prev, "github_output_node")
+            prev = "github_output_node"
+
+        wrapper.add_edge(prev, END)
         return wrapper.compile()

--- a/src/researchgraph/github_utils/graph_wrapper.py
+++ b/src/researchgraph/github_utils/graph_wrapper.py
@@ -1,0 +1,55 @@
+from typing import Any
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.graph import CompiledGraph
+from researchgraph.github_utils.github_file_io import github_input_node, github_output_node
+from researchgraph.utils.execution_timers import time_node
+
+class GraphWrapper:
+    def __init__(
+        self,
+        subgraph: CompiledGraph,
+        github_owner: str,
+        repository_name: str,
+        branch_name: str,
+        input_paths: dict[str, str],
+        output_paths: dict[str, str],
+    ):
+        self.subgraph = subgraph
+        self.github_owner = github_owner
+        self.repository_name = repository_name
+        self.branch_name = branch_name
+        self.input_paths = input_paths
+        self.output_paths = output_paths
+
+    @time_node("wrapper", "github_input_node")
+    def _github_input_node(self, state: dict) -> dict[str, Any]:
+        return github_input_node(
+            github_owner=self.github_owner,
+            repository_name=self.repository_name,
+            branch_name=self.branch_name,
+            input_paths=self.input_paths,
+        )
+
+    @time_node("wrapper", "github_output_node")
+    def _github_output_node(self, state: dict) -> dict[str, bool]:
+        result = github_output_node(
+            github_owner=self.github_owner,
+            repository_name=self.repository_name,
+            branch_name=self.branch_name,
+            output_paths=self.output_paths,
+            state=state,
+        )
+        return {"github_upload_success": result}
+
+    def build_graph(self) -> CompiledGraph:
+        wrapper = StateGraph(dict)
+        wrapper.add_node("github_input_node", self._github_input_node)
+        wrapper.add_node("run_subgraph", self.subgraph)
+        wrapper.add_node("github_output_node", self._github_output_node)
+        
+        wrapper.add_edge(START, "github_input_node")
+        wrapper.add_edge("github_input_node", "run_subgraph")
+        wrapper.add_edge("run_subgraph", "github_output_node")
+        wrapper.add_edge("github_output_node", END)
+
+        return wrapper.compile()

--- a/src/researchgraph/html_subgraph/html_subgraph.py
+++ b/src/researchgraph/html_subgraph/html_subgraph.py
@@ -39,10 +39,8 @@ class HtmlSubgraphState(
 class HtmlSubgraph:
     def __init__(
         self,
-        save_dir: str,
         llm_name: str,
     ):
-        self.save_dir = save_dir
         self.llm_name = llm_name
     
     @time_node("html_subgraph", "_convert_to_html_node")
@@ -58,7 +56,6 @@ class HtmlSubgraph:
     def _render_html_node(self, state: HtmlSubgraphState) -> dict:
         full_html = render_html(
             paper_html_content=state["paper_html_content"],
-            save_dir=self.save_dir,
         )
         return {"full_html": full_html}
 
@@ -77,19 +74,27 @@ class HtmlSubgraph:
 
 
 if __name__ == "__main__":
-    import json 
+    from researchgraph.github_utils.graph_wrapper import GraphWrapper
 
     llm_name = "o3-mini-2025-01-31"
-    save_dir = "/workspaces/researchgraph/data"
+    input_branch_name = "test"
 
     subgraph = HtmlSubgraph(
-        save_dir=save_dir,
         llm_name=llm_name,
     ).build_graph()
-    result = subgraph.invoke(html_subgraph_input_data)
-
-    output_path = os.path.join(save_dir, "test_html_subgraph.json")
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(result["full_html"], f, indent=2, ensure_ascii=False)
-
-    print(f"Saved result to {output_path}")
+    
+    wrapped_subgraph = GraphWrapper(
+        subgraph=subgraph, 
+        github_owner="auto-res2", 
+        repository_name="experiment_script_matsuzawa",
+        input_branch_name=input_branch_name, 
+        input_paths={
+            "paper_content": "data/paper_content.json", 
+        }, 
+        output_branch_name="gh-pages", 
+        output_paths={
+            "full_html": f"{input_branch_name}/index.html", 
+        }, 
+    ).build_graph()
+    result = wrapped_subgraph.invoke({})
+    print(f"result: {result}")

--- a/src/researchgraph/html_subgraph/nodes/convert_to_html.py
+++ b/src/researchgraph/html_subgraph/nodes/convert_to_html.py
@@ -79,6 +79,8 @@ Section: {{ section.name }}
 - Escape reserved characters like &, <, >.
 - Avoid adding citations or references unless already included in the input.
 
+- Do not invent or add any content (e.g., references, figures, lists) unless it exists in the input.
+
 ## Output Format:
 ```html
 <!-- Title -->

--- a/src/researchgraph/html_subgraph/nodes/render_html.py
+++ b/src/researchgraph/html_subgraph/nodes/render_html.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from jinja2 import Environment
 
@@ -57,13 +56,5 @@ def _wrap_in_html_template(paper_html_content: str) -> str:
     template = env.from_string(base_template)
     return template.render(content=paper_html_content)
 
-def _save_index_html(content: str, save_dir: str) -> None:
-    html_path = os.path.join(save_dir, "index.html")
-    with open(html_path, "w", encoding="utf-8") as f:
-        f.write(content)
-    logger.info(f"Saved HTML to: {html_path}")
-
-def render_html(paper_html_content: str, save_dir: str) -> str:
-    full_html = _wrap_in_html_template(paper_html_content)
-    _save_index_html(full_html, save_dir)
-    return full_html
+def render_html(paper_html_content: str) -> str:
+    return _wrap_in_html_template(paper_html_content)

--- a/src/researchgraph/latex_subgraph/nodes/convert_to_latex.py
+++ b/src/researchgraph/latex_subgraph/nodes/convert_to_latex.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from pydantic import BaseModel
 
 from researchgraph.utils.openai_client import openai_client
-from researchgraph.writer_subgraph.nodes.paper_writing import WritingNode
 
 logger = getLogger(__name__)
 

--- a/src/researchgraph/writer_subgraph/nodes/paper_writing.py
+++ b/src/researchgraph/writer_subgraph/nodes/paper_writing.py
@@ -165,7 +165,7 @@ Pay particular attention to fixing any errors such as:
 - Grammatical or spelling errors
 - Numerical results that do not come from explicit experiments and logs
 - Unnecessary verbosity or repetition, unclear text
-- Results or insights in the {{ note }} that have not yet need included
+- Results or insights in the context that have not yet need included
 - Any relevant figures that have not yet been included in the text"""
 
     def _replace_underscores_in_keys(self, paper_dict: dict[str, str]) -> dict[str, str]:

--- a/src/researchgraph/writer_subgraph/writer_subgraph.py
+++ b/src/researchgraph/writer_subgraph/writer_subgraph.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
         subgraph=subgraph,
         github_owner="auto-res2",
         repository_name="experiment_script_matsuzawa",
-        branch_name="test",
+        input_branch_name="test",
         input_paths={
             "base_method_text": "data/base_method_text.json",
             "new_method": "data/new_method.json",
@@ -111,6 +111,7 @@ if __name__ == "__main__":
             "experiment_code": "data/experiment_code.json",
             "output_text_data": "data/output_text_data.json",
         },
+        output_branch_name="test", 
         output_paths={
             "paper_content": "data/paper_content.json",
         },

--- a/src/researchgraph/writer_subgraph/writer_subgraph.py
+++ b/src/researchgraph/writer_subgraph/writer_subgraph.py
@@ -8,7 +8,7 @@ from researchgraph.utils.logging_utils import setup_logging
 
 from researchgraph.writer_subgraph.nodes.generate_note import generate_note
 from researchgraph.writer_subgraph.nodes.paper_writing import WritingNode
-from researchgraph.writer_subgraph.input_data import writer_subgraph_input_data
+# from researchgraph.writer_subgraph.input_data import writer_subgraph_input_data
 from researchgraph.utils.execution_timers import time_node, ExecutionTimeState
 
 setup_logging()
@@ -85,7 +85,7 @@ class WriterSubgraph:
 
 
 if __name__ == "__main__":
-    import json 
+    from researchgraph.github_utils.graph_wrapper import GraphWrapper
 
     llm_name = "o3-mini-2025-01-31"
     # llm_name = "gpt-4o-2024-11-20"
@@ -97,10 +97,23 @@ if __name__ == "__main__":
         llm_name=llm_name,
         refine_round=1,
     ).build_graph()
-    result = subgraph.invoke(writer_subgraph_input_data)
 
-    output_path = os.path.join(save_dir, "test_writer_subgraph.json")
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(result["paper_content"], f, indent=2, ensure_ascii=False)
-
-    print(f"Saved result to {output_path}")
+    wrapped_subgraph = GraphWrapper(
+        subgraph=subgraph,
+        github_owner="auto-res2",
+        repository_name="experiment_script_matsuzawa",
+        branch_name="test",
+        input_paths={
+            "base_method_text": "data/base_method_text.json",
+            "new_method": "data/new_method.json",
+            "verification_policy": "data/verification_policy.json",
+            "experiment_details": "data/experiment_details.json",
+            "experiment_code": "data/experiment_code.json",
+            "output_text_data": "data/output_text_data.json",
+        },
+        output_paths={
+            "paper_content": "data/paper_content.json",
+        },
+    ).build_graph()
+    result = wrapped_subgraph.invoke({})
+    print(f"result: {result}")


### PR DESCRIPTION
# Background & Purpose
Implemented a wrapper module to enable GitHub upload/download for each subgraph.

## Summary of Improvements
1. `GraphWrapper`: GitHub I/O as Reusable Wrapper
Introduced the `GraphWrapper` module to wrap any LangGraph `CompiledGraph` with GitHub input/output capability.
This allows subgraph state (e.g., JSON, PDF or HTML) to be stored in and loaded from GitHub, enabling checkpointing.

2. UploadSubgraph Deprecation (Planned)
`UploadSubgraph` is now redundant and will be removed in favor of `GraphWrapper`.
Note: Upload of `README.md` and execution logs is not yet supported by `GraphWrapper`; they are still handled via `UploadSubgraph`.

Details of the implementation are described below:

<details>
<summary><code>1. src/researchgraph/github_utils/graph_wrapper.py</code></summary>

**Overview**
- Defines `GraphWrapper` to wrap any subgraph with GitHub input/output.

**Class Structure**
- `_github_input_node()`:
  - Downloads specified inputs from GitHub using:
  ```python
  github_owner, repository_name, input_branch_name, input_paths
  ```
- ` _github_output_node()`:
  - Uploads outputs to GitHub using:
  ```python
  github_owner, repository_name, output_branch_name, output_paths
  ```
- `build_graph()`:
  - Automatically inserts I/O nodes around the subgraph.

Supported
✅ Load JSON state from GitHub
✅ Save JSON, PDF, HTML (via GitHub Pages if output branch is gh-pages)
🚫 README.md and logs (not yet handled)

**Interface**
```python
GraphWrapper(
  subgraph=...,
  github_owner=...,
  repository_name=...,
  input_branch_name=...,
  input_paths={...},
  output_branch_name=...,
  output_paths={...}
).build_graph()
```
</details>

<details>
<summary><code>2. src/researchgraph/github_utils/github_file_io.py</code></summary>

**Overview**
- Centralizes all GitHub I/O logic using the REST API.

**Key Method**:
- `github_input_node():`
  - Calls `_download_file_from_github()` to fetch data.
  
- `github_output_node:`
  - Calls `_encode_content()` and `_upload_file_to_github()` to push results.

</details>

<details>
<summary><code>3. Others</code></summary>

**Changed**:
- `src/researchgraph/html_subgraph/nodes/convert_to_html.py`: 
  - Updated prompt to avoid generating fake image references.

- `src/researchgraph/html_subgraph/nodes/render_html.py`: 
  - Removed `_save_index_html()` as it's no longer needed.
</details>