### PR TITLE
Add GitHub wrapper with OutputState-limited upload and conflict-aware branch creation

### DIFF
--- a/src/researchgraph/github_utils/github_file_io.py
+++ b/src/researchgraph/github_utils/github_file_io.py
@@ -90,13 +90,14 @@ def upload_to_github(
     branch_name: str,
     output_path: str,
     state: dict[str, Any],
-    upload_key: str | None = None, 
+    extra_files: list[tuple[str, str, list[str]]] | None = None,  # [branch_name, repo_path, local_paths]
     commit_message: str = "Upload file via ResearchGraph",
 ) -> bool:
-    logger.info(f"[GitHub I/O] Uploading full state to: {output_path}")
+    logger.info(f"[GitHub I/O] Uploading state to: {output_path}")
+    success = True
+
     try:
-        content = state[upload_key] if upload_key else state
-        file_bytes = _encode_content(content)
+        file_bytes = _encode_content(state)
         _upload_file_bytes_to_github(
             github_owner, 
             repository_name, 
@@ -105,10 +106,32 @@ def upload_to_github(
             file_bytes, 
             commit_message=commit_message, 
         )
-        return True
     except Exception as e:
         logger.warning(f"Failed to upload state to {output_path}: {e}", exc_info=True)
-        return False
+        success = False
+
+    if extra_files:
+        for extra_branch, repo_base_path, local_paths in extra_files:
+            for local_path in local_paths:
+                try:
+                    filename = os.path.basename(local_path)
+                    repo_path = os.path.join(repo_base_path, filename).replace("\\", "/")
+                    with open(local_path, "rb") as f:
+                        file_bytes = f.read()
+
+                    _upload_file_bytes_to_github(
+                        github_owner,
+                        repository_name,
+                        extra_branch,
+                        repo_path,
+                        file_bytes,
+                        commit_message=commit_message,
+                    )
+                    logger.info(f"[GitHub I/O] Uploaded extra file: {local_path} to {repo_path}")
+                except Exception as e:
+                    logger.warning(f"Failed to upload extra file {local_path} to {repo_path}: {e}", exc_info=True)
+                    success = False
+    return success
 
 def _encode_content(value: Any) -> bytes:
     if isinstance(value, str) and os.path.isfile(value):
@@ -120,3 +143,29 @@ def _encode_content(value: Any) -> bytes:
         return value.encode("utf-8")
     else:
         return json.dumps(value, indent=2, ensure_ascii=False).encode("utf-8")
+
+
+def create_branch_on_github(
+    github_owner: str,
+    repository_name: str,
+    new_branch_name: str,
+    base_branch_name: str,
+    ) -> None:
+    ref_url = f"https://api.github.com/repos/{github_owner}/{repository_name}/git/ref/heads/{base_branch_name}"
+    ref_response = retry_request(fetch_api_data, ref_url, headers=_build_headers(), method="GET")
+    if not ref_response or "object" not in ref_response or "sha" not in ref_response["object"]:
+        logger.error(f"Failed to get base branch '{base_branch_name}' SHA")
+        raise ValueError(f"Failed to get base branch '{base_branch_name}' SHA")
+    
+    base_sha = ref_response["object"]["sha"]
+    create_url = f"https://api.github.com/repos/{github_owner}/{repository_name}/git/refs"
+    payload = {
+        "ref": f"refs/heads/{new_branch_name}",
+        "sha": base_sha,
+    }
+    try:
+        retry_request(fetch_api_data, create_url, headers=_build_headers(), data=payload, method="POST")
+        logger.info(f"Created new branch: {new_branch_name} based on {base_branch_name}")
+    except Exception as e:
+        logger.warning(f"[GitHub] Branch creation failed or already exists: {new_branch_name} — {e}", exc_info=True)
+        raise

--- a/src/researchgraph/github_utils/graph_wrapper.py
+++ b/src/researchgraph/github_utils/graph_wrapper.py
@@ -1,84 +1,150 @@
+import logging
+from copy import deepcopy
+from datetime import datetime, timezone
 from typing import Any, Protocol, TypeVar, TypedDict
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.graph import CompiledGraph
-from researchgraph.github_utils.github_file_io import download_from_github, upload_to_github
+from researchgraph.utils.logging_utils import setup_logging
+from researchgraph.github_utils.github_file_io import download_from_github, upload_to_github, create_branch_on_github
 from researchgraph.utils.execution_timers import time_node
 
+setup_logging()
+logger = logging.getLogger(__name__)
 
 # class GraphWrapperState(TypedDict):
 #     github_upload_success: bool
 
-
+    
 class GraphWrapper:
     def __init__(
         self,
         subgraph: CompiledGraph,
+        output_state: type[TypedDict], 
         github_owner: str,
         repository_name: str,
-        input_branch_name: str | None = None, 
-        input_path: str | None = None,
-        output_branch_name: str | None = None,
-        output_path: str | None = None,
-        upload_key: str | None = None, 
+        input_branch_name: str, 
+        input_path: str,
+        output_branch_name: str,
+        output_path: str,
+        extra_files: list[tuple[str, str, list[str]]] | None = None, 
     ):
         self.subgraph = subgraph
+        self.output_state = output_state
         self.github_owner = github_owner
         self.repository_name = repository_name
         self.input_branch_name = input_branch_name
         self.input_path = input_path
         self.output_branch_name = output_branch_name
         self.output_path = output_path
-        self.upload_key = upload_key
+        self.extra_files = extra_files
 
+        self.output_state_keys = (
+            list(output_state.__annotations__.keys()) if output_state else []
+        )
+
+    def _deep_merge(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
+        result = deepcopy(old)
+        for k, v in new.items():
+            if (
+                k in result
+                and isinstance(result[k], dict)
+                and isinstance(v, dict)
+            ):
+                result[k] = self._deep_merge(result[k], v)
+            else:
+                result[k] = deepcopy(v)
+        return result
+        
+    def _create_branch_name(self) -> str:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        subgraph_name = getattr(self.subgraph, "__source_subgraph_name__", "subgraph").lower()
+        new_branch = f"{self.output_branch_name}-{subgraph_name}-{ts}"
+    
+        create_branch_on_github(
+            github_owner=self.github_owner,
+            repository_name=self.repository_name,
+            new_branch_name=new_branch,
+            base_branch_name=self.output_branch_name
+        )
+
+        logger.info(f"Created new GitHub branch: {new_branch}")
+        return new_branch
+    
+    def _format_extra_files(self, branch_name: str) -> list[tuple[str, str, list[str]]] | None:
+        if self.extra_files is None:
+            return None
+        
+        formatted_files = []
+        for target_branch, target_path, file_paths in self.extra_files:
+            tb = target_branch.replace("{{ branch_name }}", branch_name)
+            tp = target_path.replace("{{ branch_name }}", branch_name)
+            fps = [fp.replace("{{ branch_name }}", branch_name) for fp in file_paths]
+            formatted_files.append((tb, tp, fps))
+
+        return formatted_files
 
     def _call_api(self) -> None:
         pass
     
     @time_node("wrapper", "download_from_github")
     def _download_from_github(self, state: dict[str, Any]) -> dict[str, Any]:
-        return download_from_github(
+        original_state = download_from_github(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
             branch_name=self.input_branch_name,
             input_path=self.input_path,
         )
+        return {
+            "original_state": deepcopy(original_state)  
+        }
     
     @time_node("wrapper", "run_subgraph")
     def _run_subgraph(self, state: dict[str, Any]) -> dict[str, Any]:
-        return self.subgraph.invoke(state)
-
+        original_state = state.get("original_state")
+        output_state = self.subgraph.invoke(original_state)
+        return {
+            "original_state": original_state, 
+            "output_state": output_state, 
+        }
 
     @time_node("wrapper", "upload_to_github")
     def _upload_to_github(self, state: dict[str, Any]) -> dict[str, bool]:
+
+        original_state = state.get("original_state", {})
+        raw_output_state = state.get("output_state", {})
+        output_state = {k: raw_output_state[k] for k in self.output_state_keys if k in raw_output_state}
+        merged_state = self._deep_merge(original_state, output_state)
+
+        key_conflict = bool(set(original_state) & set(output_state))
+        if key_conflict:
+            final_branch = self._create_branch_name()
+            logger.info(f"Key conflict detected. Created new branch: {final_branch}")
+        else:
+            final_branch = self.output_branch_name
+            logger.info(f"No key conflict. Using existing branch: {final_branch}")
+
+        formatted_extra_files = self._format_extra_files(final_branch)
+
         result = upload_to_github(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
-            branch_name=self.output_branch_name,
+            branch_name=final_branch,
             output_path=self.output_path,
-            state=state,
-            upload_key=self.upload_key, 
+            state=merged_state,
+            extra_files=formatted_extra_files, 
         )
         return {"github_upload_success": result}
 
     def build_graph(self) -> CompiledGraph:
         wrapper = StateGraph(dict)
-        prev = START
+        wrapper.add_node("download_from_github", self._download_from_github)
+        wrapper.add_node("run_subgraph", self._run_subgraph)
+        wrapper.add_node("upload_to_github", self._upload_to_github)
 
-        if self.input_path and self.input_branch_name:
-            wrapper.add_node("download_from_github", self._download_from_github)
-            wrapper.add_edge(prev, "download_from_github")
-            prev = "download_from_github"
-
-        wrapper.add_node("run_subgraph", self.subgraph)
-        wrapper.add_edge(prev, "run_subgraph")
-        prev = "run_subgraph"
-
-        if self.output_path and self.output_branch_name:
-            wrapper.add_node("upload_to_github", self._upload_to_github)
-            wrapper.add_edge(prev, "upload_to_github")
-            prev = "upload_to_github"
-
-        wrapper.add_edge(prev, END)
+        wrapper.add_edge(START, "download_from_github")
+        wrapper.add_edge("download_from_github", "run_subgraph")
+        wrapper.add_edge("run_subgraph", "upload_to_github")
+        wrapper.add_edge("upload_to_github", END)
         return wrapper.compile()
 
 
@@ -90,33 +156,34 @@ T = TypeVar("T", bound=BuildableSubgraph)
 
 # TODO: Add support for subgraph API invocation
 def create_wrapped_subgraph(
-    subgraph_cls: type[T],
+    subgraph: type[T],
+    output_state: type[TypedDict], 
     github_owner: str, 
     repository_name: str,
-    input_branch_name: str | None = None,
-    input_path: str | None = None,
-    output_branch_name: str | None = None,
-    output_path: str | None = None,
-    upload_key: str | None = None, 
+    input_branch_name: str,
+    input_path: str,
+    output_branch_name: str,
+    output_path: str,
+    extra_files: list[tuple[str, str, list[str]]] | None = None, 
     *args: Any, 
     **kwargs: Any,
 ) -> CompiledGraph:
 
-    subgraph = subgraph_cls(
-        *args, 
-        **kwargs
-    ).build_graph()
+    subgraph_instance = subgraph(*args, **kwargs)
+    compiled_subgraph = subgraph_instance.build_graph()
+    setattr(compiled_subgraph, "__source_subgraph_name__", subgraph_instance.__class__.__name__)
 
     if input_path or output_path:
         return GraphWrapper(
-            subgraph=subgraph,
+            subgraph=compiled_subgraph,
+            output_state=output_state, 
             github_owner=github_owner,
             repository_name=repository_name,
             input_branch_name=input_branch_name,
             input_path=input_path,
             output_branch_name=output_branch_name,
             output_path=output_path,
-            upload_key=upload_key, 
+            extra_files = extra_files, 
         ).build_graph()
 
-    return subgraph
+    return compiled_subgraph

--- a/src/researchgraph/github_utils/graph_wrapper.py
+++ b/src/researchgraph/github_utils/graph_wrapper.py
@@ -5,8 +5,13 @@ from typing import Any, Protocol, TypeVar, TypedDict
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.graph import CompiledGraph
 from researchgraph.utils.logging_utils import setup_logging
-from researchgraph.github_utils.github_file_io import download_from_github, upload_to_github, create_branch_on_github
 from researchgraph.utils.execution_timers import time_node
+from researchgraph.github_utils.github_file_io import (
+    download_from_github, 
+    upload_to_github, 
+    create_branch_on_github, 
+    ExtraFileConfig, 
+)
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -14,34 +19,39 @@ logger = logging.getLogger(__name__)
 # class GraphWrapperState(TypedDict):
 #     github_upload_success: bool
 
-    
-class GraphWrapper:
+class GithubGraphWrapper:
     def __init__(
         self,
         subgraph: CompiledGraph,
         output_state: type[TypedDict], 
-        github_owner: str,
-        repository_name: str,
-        input_branch_name: str | None = None,  
-        input_path: str | None = None,
-        output_branch_name: str | None = None,
-        output_path: str | None = None,
-        extra_files: list[tuple[str, str, list[str]]] | None = None, 
+        github_repository: str, 
+        branch_name: str,  
+        research_file_path: str = ".research/research_history.json", 
+        extra_files: list[ExtraFileConfig] | None = None, 
+        perform_download: bool = True, 
+        perform_upload: bool = True, 
+        public_branch: str = "gh-pages", 
     ):
         self.subgraph = subgraph
         self.output_state = output_state
-        self.github_owner = github_owner
-        self.repository_name = repository_name
-        self.input_branch_name = input_branch_name
-        self.input_path = input_path
-        self.output_branch_name = output_branch_name
-        self.output_path = output_path
+        self.github_repository = github_repository
+        self.branch_name = branch_name
+        self.research_file_path = research_file_path
         self.extra_files = extra_files
+        self.perform_download = perform_download
+        self.perform_upload = perform_upload
+        self.public_branch = public_branch
 
         self.subgraph_name = getattr(subgraph, "__source_subgraph_name__", "subgraph").lower()
         self.output_state_keys = (
             list(output_state.__annotations__.keys()) if output_state else []
         )
+        try:
+            owner, repository = github_repository.split("/", 1)
+        except ValueError:
+            raise ValueError("Repo string must be in the format 'owner/repository'")
+        self.github_owner = owner
+        self.repository_name = repository
 
     def _deep_merge(self, old: dict[str, Any], new: dict[str, Any]) -> dict[str, Any]:
         result = deepcopy(old)
@@ -58,28 +68,32 @@ class GraphWrapper:
         
     def _create_branch_name(self) -> str:
         ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-        new_branch = f"{self.output_branch_name}-{self.subgraph_name}-{ts}"
+        new_branch = f"{self.branch_name}-{self.subgraph_name}-{ts}"
     
         create_branch_on_github(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
             new_branch_name=new_branch,
-            base_branch_name=self.output_branch_name
+            base_branch_name=self.branch_name
         )
 
         logger.info(f"Created new GitHub branch: {new_branch}")
         return new_branch
     
-    def _format_extra_files(self, branch_name: str) -> list[tuple[str, str, list[str]]] | None:
+    def _format_extra_files(self, branch_name: str) -> list[ExtraFileConfig] | None:
         if self.extra_files is None:
             return None
         
         formatted_files = []
-        for target_branch, target_path, file_paths in self.extra_files:
-            tb = target_branch.replace("{{ branch_name }}", branch_name)
-            tp = target_path.replace("{{ branch_name }}", branch_name)
-            fps = [fp.replace("{{ branch_name }}", branch_name) for fp in file_paths]
-            formatted_files.append((tb, tp, fps))
+        for file_config in self.extra_files:
+            tb = file_config["upload_branch"].replace("{{ branch_name }}", branch_name)
+            tp = file_config["upload_dir"].replace("{{ branch_name }}", branch_name)
+            fps = [fp.replace("{{ branch_name }}", branch_name) for fp in file_config["local_file_paths"]]
+            formatted_files.append({
+                "upload_branch": tb, 
+                "upload_dir": tp, 
+                "local_file_paths": fps, 
+            })
 
         return formatted_files
 
@@ -91,8 +105,8 @@ class GraphWrapper:
         original_state = download_from_github(
             github_owner=self.github_owner,
             repository_name=self.repository_name,
-            branch_name=self.input_branch_name,
-            input_path=self.input_path,
+            branch_name=self.branch_name,
+            input_path=self.research_file_path,
         )
         return {
             "original_state": deepcopy(original_state)  
@@ -100,7 +114,7 @@ class GraphWrapper:
     
     @time_node("wrapper", "run_subgraph")
     def _run_subgraph(self, state: dict[str, Any]) -> dict[str, Any]:
-        original_state = state.get("original_state")
+        original_state = state.get("original_state") or {}
         output_state = self.subgraph.invoke(original_state)
         return {
             "original_state": original_state, 
@@ -120,7 +134,7 @@ class GraphWrapper:
             final_branch = self._create_branch_name()
             logger.info(f"Key conflict detected. Created new branch: {final_branch}")
         else:
-            final_branch = self.output_branch_name
+            final_branch = self.branch_name
             logger.info(f"No key conflict. Using existing branch: {final_branch}")
 
         formatted_extra_files = self._format_extra_files(final_branch)
@@ -129,18 +143,28 @@ class GraphWrapper:
             github_owner=self.github_owner,
             repository_name=self.repository_name,
             branch_name=final_branch,
-            output_path=self.output_path,
+            output_path=self.research_file_path,
             state=merged_state,
             extra_files=formatted_extra_files, 
             commit_message=f"Update by subgraph: {self.subgraph_name}"
         )
+        if formatted_extra_files is not None:
+            for file_config in formatted_extra_files:
+                if file_config["upload_branch"].lower() == self.public_branch.lower():
+                    target_path = file_config["upload_dir"]
+                    if not target_path.endswith("/"):
+                        target_path += "/"
+                    github_pages_url = f"https://{self.github_owner}.github.io/{self.repository_name}/{target_path}"
+                    logger.info(f"Uploaded HTML available at: {github_pages_url}")
+                    break
+
         return {"github_upload_success": result}
 
     def build_graph(self) -> CompiledGraph:
         wrapper = StateGraph(dict[str, Any])
         prev = START
 
-        if self.input_path and self.input_branch_name:
+        if self.perform_download:
             wrapper.add_node("download_from_github", self._download_from_github)
             wrapper.add_edge(prev, "download_from_github")
             prev = "download_from_github"
@@ -149,7 +173,7 @@ class GraphWrapper:
         wrapper.add_edge(prev, "run_subgraph")
         prev = "run_subgraph"
 
-        if self.output_path and self.output_branch_name:
+        if self.perform_upload:
             wrapper.add_node("upload_to_github", self._upload_to_github)
             wrapper.add_edge(prev, "upload_to_github")
             prev = "upload_to_github"
@@ -168,32 +192,39 @@ T = TypeVar("T", bound=BuildableSubgraph)
 def create_wrapped_subgraph(
     subgraph: type[T],
     output_state: type[TypedDict], 
-    github_owner: str, 
-    repository_name: str,
-    input_branch_name: str,
-    input_path: str,
-    output_branch_name: str,
-    output_path: str,
-    extra_files: list[tuple[str, str, list[str]]] | None = None, 
-    *args: Any, 
-    **kwargs: Any,
-) -> CompiledGraph:
+) -> type:
+    
+    class GithubGraphRunner(GithubGraphWrapper):
+        def __init__(
+            self, 
+            github_repository: str,
+            branch_name: str,
+            research_file_path: str = ".research/research_history.json",
+            extra_files: list[ExtraFileConfig] | None = None,
+            perform_download: bool = True, 
+            perform_upload: bool = True, 
+            public_branch: str = "gh-pages", 
+            *args: Any,
+            **kwargs: Any,
+        ):
+            
+            subgraph_instance = subgraph(*args, **kwargs)
+            compiled_subgraph = subgraph_instance.build_graph()
+            setattr(compiled_subgraph, "__source_subgraph_name__", subgraph_instance.__class__.__name__)
+            super().__init__(
+                subgraph=compiled_subgraph,
+                output_state=output_state,
+                github_repository=github_repository, 
+                branch_name=branch_name,
+                research_file_path=research_file_path,
+                extra_files=extra_files,
+                perform_download=perform_download, 
+                perform_upload=perform_upload, 
+                public_branch=public_branch, 
+            )
 
-    subgraph_instance = subgraph(*args, **kwargs)
-    compiled_subgraph = subgraph_instance.build_graph()
-    setattr(compiled_subgraph, "__source_subgraph_name__", subgraph_instance.__class__.__name__)
-
-    if input_path or output_path:
-        return GraphWrapper(
-            subgraph=compiled_subgraph,
-            output_state=output_state, 
-            github_owner=github_owner,
-            repository_name=repository_name,
-            input_branch_name=input_branch_name,
-            input_path=input_path,
-            output_branch_name=output_branch_name,
-            output_path=output_path,
-            extra_files = extra_files, 
-        ).build_graph()
-
-    return compiled_subgraph
+        def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+            graph = self.build_graph()
+            return graph.invoke(inputs)
+        
+    return GithubGraphRunner

--- a/src/researchgraph/html_subgraph/nodes/render_html.py
+++ b/src/researchgraph/html_subgraph/nodes/render_html.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from jinja2 import Environment
 
@@ -63,5 +64,13 @@ def _wrap_in_html_template(paper_html_content: str) -> str:
     template = env.from_string(base_template)
     return template.render(content=paper_html_content)
 
-def render_html(paper_html_content: str) -> str:
-    return _wrap_in_html_template(paper_html_content)
+def _save_index_html(content: str, save_dir: str) -> None:
+    html_path = os.path.join(save_dir, "index.html")
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    logger.info(f"Saved HTML to: {html_path}")
+
+def render_html(paper_html_content: str, save_dir: str) -> str:
+    full_html = _wrap_in_html_template(paper_html_content)
+    _save_index_html(full_html, save_dir)
+    return full_html

--- a/src/researchgraph/latex_subgraph/latex_subgraph.py
+++ b/src/researchgraph/latex_subgraph/latex_subgraph.py
@@ -25,7 +25,6 @@ class LatexSubgraphHiddenState(TypedDict):
 
 class LatexSubgraphOutputState(TypedDict):
     tex_text: str
-    pdf_file_path: str
 
 
 class LatexSubgraphState(
@@ -71,7 +70,6 @@ class LatexSubgraph:
         )
         return {
             "tex_text": tex_text, 
-            "pdf_file_path": self.pdf_file_path
         }
 
     def build_graph(self) -> CompiledGraph:
@@ -89,19 +87,27 @@ class LatexSubgraph:
 
 if __name__ == "__main__":
     from researchgraph.github_utils.graph_wrapper import create_wrapped_subgraph
-    from researchgraph.latex_subgraph.latex_subgraph import LatexSubgraph
+    from researchgraph.latex_subgraph.latex_subgraph import LatexSubgraph, LatexSubgraphOutputState
 
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/researchgraph/data"
 
+    branch_name = "branch-1"
+    path = "research/research_history.json"
+    extra_files = [
+        ("{{ branch_name }}", "research/", [f"{save_dir}/paper.pdf"]), 
+    ]
+
     wrapped_subgraph = create_wrapped_subgraph(
-        subgraph_cls=LatexSubgraph,
+        subgraph=LatexSubgraph,
+        output_state=LatexSubgraphOutputState, 
         github_owner="auto-res2",
         repository_name="experiment_script_matsuzawa",
-        input_branch_name="test",
-        input_path="research/research_record.json",
-        output_branch_name="test",
-        output_path="research/research_record.json",
+        input_branch_name=branch_name, 
+        input_path=path, 
+        output_branch_name=branch_name, 
+        output_path=path, 
+        extra_files=extra_files, 
         llm_name=llm_name,
         save_dir=save_dir, 
     )

--- a/src/researchgraph/latex_subgraph/latex_subgraph.py
+++ b/src/researchgraph/latex_subgraph/latex_subgraph.py
@@ -10,6 +10,7 @@ from researchgraph.latex_subgraph.nodes.convert_to_latex import convert_to_latex
 from researchgraph.latex_subgraph.nodes.compile_to_pdf import LatexNode
 from researchgraph.latex_subgraph.input_data import latex_subgraph_input_data
 from researchgraph.utils.execution_timers import time_node, ExecutionTimeState
+from researchgraph.github_utils.graph_wrapper import create_wrapped_subgraph
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -83,34 +84,32 @@ class LatexSubgraph:
         graph_builder.add_edge("latex_node", END)
 
         return graph_builder.compile()
+    
+
+LatexConverter =  create_wrapped_subgraph(LatexSubgraph, LatexSubgraphOutputState)
 
 
 if __name__ == "__main__":
-    from researchgraph.github_utils.graph_wrapper import create_wrapped_subgraph
-    from researchgraph.latex_subgraph.latex_subgraph import LatexSubgraph, LatexSubgraphOutputState
-
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/researchgraph/data"
 
-    branch_name = "branch-1"
-    path = "research/research_history.json"
+    github_repository="auto-res2/experiment_script_matsuzawa"
+    branch_name = "base-branch"
     extra_files = [
-        ("{{ branch_name }}", "research/", [f"{save_dir}/paper.pdf"]), 
+        {
+            "upload_branch": "{{ branch_name }}", 
+            "upload_dir": ".research/", 
+            "local_file_paths": [f"{save_dir}/paper.pdf"], 
+        }
     ]
 
-    wrapped_subgraph = create_wrapped_subgraph(
-        subgraph=LatexSubgraph,
-        output_state=LatexSubgraphOutputState, 
-        github_owner="auto-res2",
-        repository_name="experiment_script_matsuzawa",
-        input_branch_name=branch_name, 
-        input_path=path, 
-        output_branch_name=branch_name, 
-        output_path=path, 
+    latex_converter = LatexConverter(
+        github_repository=github_repository,
+        branch_name=branch_name,
         extra_files=extra_files, 
         llm_name=llm_name,
         save_dir=save_dir, 
     )
 
-    result = wrapped_subgraph.invoke({})
+    result = latex_converter.run({})
     print(f"result: {result}")

--- a/src/researchgraph/research_graph.py
+++ b/src/researchgraph/research_graph.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
         # "https://eccv.ecva.net/virtual/2024/papers.html?filter=title",
     ]
     add_paper_num = 3
-    repository = "auto-res2/auto-research"
+    repository = "auto-res2/experiment_script_matsuzawa"
     max_code_fix_iteration = 5
 
     research_graph = ResearchGraph(

--- a/src/researchgraph/research_graph.py
+++ b/src/researchgraph/research_graph.py
@@ -193,6 +193,7 @@ class ResearchGraph:
         def html_subgraph(state: dict):
             subgraph = HtmlSubgraph(
                 llm_name="o3-mini-2025-01-31",
+                save_dir=self.save_dir, 
             ).build_graph()
             return subgraph.invoke(state)
 

--- a/src/researchgraph/writer_subgraph/writer_subgraph.py
+++ b/src/researchgraph/writer_subgraph/writer_subgraph.py
@@ -86,7 +86,7 @@ class WriterSubgraph:
 
 
 if __name__ == "__main__":
-    from researchgraph.writer_subgraph.writer_subgraph import WriterSubgraph
+    from researchgraph.writer_subgraph.writer_subgraph import WriterSubgraph, WriterSubgraphOutputState
     from researchgraph.github_utils.graph_wrapper import create_wrapped_subgraph
 
     llm_name = "o3-mini-2025-01-31"
@@ -94,14 +94,17 @@ if __name__ == "__main__":
     # llm_name = "gpt-4o-mini-2024-07-18"
     save_dir = "/workspaces/researchgraph/data"
 
+    branch_name = "branch-1" 
+
     wrapped_subgraph = create_wrapped_subgraph(
-        subgraph_cls=WriterSubgraph,
+        subgraph=WriterSubgraph,
+        output_state=WriterSubgraphOutputState, 
         github_owner="auto-res2",
         repository_name="experiment_script_matsuzawa",
-        input_branch_name="test",
-        input_path="research/research_record.json", 
-        output_branch_name="test",
-        output_path="research/research_record.json",
+        input_branch_name=branch_name,
+        input_path="research/input_data_writer_subgraph.json", 
+        output_branch_name=branch_name,
+        output_path="research/research_history.json",
         save_dir=save_dir,
         llm_name=llm_name,
         refine_round=1,

--- a/src/researchgraph/writer_subgraph/writer_subgraph.py
+++ b/src/researchgraph/writer_subgraph/writer_subgraph.py
@@ -11,6 +11,7 @@ from researchgraph.writer_subgraph.nodes.paper_writing import WritingNode
 
 # from researchgraph.writer_subgraph.input_data import writer_subgraph_input_data
 from researchgraph.utils.execution_timers import time_node, ExecutionTimeState
+from researchgraph.github_utils.graph_wrapper import create_wrapped_subgraph
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -83,32 +84,26 @@ class WriterSubgraph:
         graph_builder.add_edge("writeup_node", END)
 
         return graph_builder.compile()
+    
+
+PaperWriter = create_wrapped_subgraph(WriterSubgraph, WriterSubgraphOutputState)
 
 
 if __name__ == "__main__":
-    from researchgraph.writer_subgraph.writer_subgraph import WriterSubgraph, WriterSubgraphOutputState
-    from researchgraph.github_utils.graph_wrapper import create_wrapped_subgraph
-
     llm_name = "o3-mini-2025-01-31"
-    # llm_name = "gpt-4o-2024-11-20"
-    # llm_name = "gpt-4o-mini-2024-07-18"
     save_dir = "/workspaces/researchgraph/data"
+    refine_round = 1
 
-    branch_name = "branch-1" 
+    github_repository="auto-res2/experiment_script_matsuzawa"
+    branch_name = "base-branch" 
 
-    wrapped_subgraph = create_wrapped_subgraph(
-        subgraph=WriterSubgraph,
-        output_state=WriterSubgraphOutputState, 
-        github_owner="auto-res2",
-        repository_name="experiment_script_matsuzawa",
-        input_branch_name=branch_name,
-        input_path="research/input_data_writer_subgraph.json", 
-        output_branch_name=branch_name,
-        output_path="research/research_history.json",
-        save_dir=save_dir,
+    paper_writer = PaperWriter(
+        github_repository=github_repository, 
+        branch_name=branch_name,
         llm_name=llm_name,
-        refine_round=1,
+        save_dir=save_dir,
+        refine_round=refine_round,
     )
 
-    result = wrapped_subgraph.invoke({})
+    result = paper_writer.run({})
     print(f"result: {result}")


### PR DESCRIPTION
# Background & Purpose
This PR adds `create_wrapped_subgraph()`, a factory function that generates a `GithubGraphRunner` class for any LangGraph subgraph. The runner integrates GitHub-based state management—loading input, executing the subgraph, and uploading results. Each runner is self-contained, exposes the subgraph’s functionality via `.run()`, and can be packaged for distribution.

Details of the implementation are described below:

<details>
<summary><code>1. src/researchgraph/github_utils/graph_wrapper.py</code></summary>

**Overview**:
`GithubGraphWrapper` provides GitHub I/O integration for `CompiledGraph` objects:
- Loads `.research/research_history.json` from GitHub
- Runs the subgraph
- Uploads merged output, resolving key conflicts by creating new branches
- Supports dynamic upload of extra files (e.g., HTML to gh-pages)

**Key Components**:
- `GithubGraphWrapper`: Base class that wraps execution and I/O logic

  **Key Method**:
  - `_download_from_github`: Loads `original_state` from GitHub
  - `_run_subgraph`: Runs subgraph with `original_state`, returns `output_state`
  - `_upload_to_github`: Merges states and uploads; creates new branch if needed
  - `_create_branch_name`: Generates timestamped branch name
  -`_format_extra_files`: Replaces `{{ branch_name }}` in upload paths
  - `_call_api`: Reserved for future external API execution

- `create_wrapped_subgraph()`: Returns a `GithubGraphRunner` class bound to a given subgraph
  - `GithubGraphRunner`: Executable class that inherits from `GithubGraphWrapper`, runnable via `.run()`, and suitable for packaging

**Usage Example:**
```python 
HtmlConverter = create_wrapped_subgraph(HtmlSubgraph, HtmlOutputState)

html_converterr = HtmlConverter(
      github_repository=github_repository,  # "auto-res2/experiment_script_matsuzawa"
      branch_name=branch_name,
      extra_files=extra_files,
      llm_name=llm_name,
      save_dir=save_dir,
)
result = html_converter.run({})
```
</details>

<details>
<summary><code>2. src/researchgraph/github_utils/github_file_io.py</code></summary>

**Overview**:
Extends GitHub I/O utilities to support:
- Uploading multiple local files (`extra_files`) to specified branches/paths
- Creating new branches dynamically based on an existing branch

**Key Changed**:
- `upload_to_github:`
  - Now accepts `extra_files` (`ExtraFileConfig`) to upload additional files such as HTML or PDF to custom paths or branches.
- `create_branch_on_github:`
  - Creates a new timestamped branch based on a given base branch, used when key conflicts are detected.
- Improved error handling and logging for both upload and branch creation processes.

**New Function**:
```python
def create_branch_on_github(
    github_owner: str,
    repository_name: str,
    new_branch_name: str,
    base_branch_name: str,
) -> None
```
</details>
