### PR TITLE
update GtihubGraphWrapper

### DIFF
--- a/src/researchgraph/analytic_subgraph/analytic_subgraph.py
+++ b/src/researchgraph/analytic_subgraph/analytic_subgraph.py
@@ -71,6 +71,7 @@ class AnalyticSubgraph:
 
 Analyst = create_wrapped_subgraph(
     AnalyticSubgraph,
+    AnalyticSubgraphInputState, 
     AnalyticSubgraphOutputState,
 )
 

--- a/src/researchgraph/executor_subgraph/executor_subgraph.py
+++ b/src/researchgraph/executor_subgraph/executor_subgraph.py
@@ -227,6 +227,7 @@ class ExecutorSubgraph:
 
 Executor = create_wrapped_subgraph(
     ExecutorSubgraph,
+    ExecutorSubgraphInputState, 
     ExecutorSubgraphOutputState,
 )
 

--- a/src/researchgraph/experimental_plan_subgraph/experimental_plan_subgraph.py
+++ b/src/researchgraph/experimental_plan_subgraph/experimental_plan_subgraph.py
@@ -211,6 +211,7 @@ class ExperimentalPlanSubgraph:
 
 ExperimentalPlaner = create_wrapped_subgraph(
     ExperimentalPlanSubgraph,
+    ExperimentalPlanSubgraphInputState, 
     ExperimentalPlanSubgraphOutputState,
 )
 

--- a/src/researchgraph/generator_subgraph/generator_subgraph.py
+++ b/src/researchgraph/generator_subgraph/generator_subgraph.py
@@ -66,6 +66,7 @@ class GeneratorSubgraph:
 
 Generator = create_wrapped_subgraph(
     GeneratorSubgraph,
+    GeneratorSubgraphInputState, 
     GeneratorSubgraphOutputState,
 )
 

--- a/src/researchgraph/github_utils/graph_wrapper.py
+++ b/src/researchgraph/github_utils/graph_wrapper.py
@@ -131,7 +131,7 @@ class GithubGraphWrapper:
         if input_conflict or output_conflict:
             reason = "Input mismatch" if input_conflict else "Output key conflict"
             final_branch = self._create_branch_name()
-            logger.info("%s detected. Created new branch: %s", reason, final_branch)
+            logger.info(f"{reason} detected. Created new branch: {final_branch}")
         else:
             logger.info(f"No conflict. Using existing branch: {final_branch}")
 

--- a/src/researchgraph/github_utils/graph_wrapper.py
+++ b/src/researchgraph/github_utils/graph_wrapper.py
@@ -23,6 +23,7 @@ class GithubGraphWrapper:
     def __init__(
         self,
         subgraph: CompiledGraph,
+        input_state: type[TypedDict], 
         output_state: type[TypedDict],
         github_repository: str,
         branch_name: str,
@@ -33,6 +34,7 @@ class GithubGraphWrapper:
         public_branch: str = "gh-pages",
     ):
         self.subgraph = subgraph
+        self.input_state = input_state
         self.output_state = output_state
         self.github_repository = github_repository
         self.branch_name = branch_name
@@ -45,6 +47,9 @@ class GithubGraphWrapper:
         self.subgraph_name = getattr(
             subgraph, "__source_subgraph_name__", "subgraph"
         ).lower()
+        self.input_state_keys = (
+            list(input_state.__annotations__.keys()) if input_state else []
+        )
         self.output_state_keys = (
             list(output_state.__annotations__.keys()) if output_state else []
         )
@@ -111,42 +116,62 @@ class GithubGraphWrapper:
             branch_name=self.branch_name,
             input_path=self.research_file_path,
         )
-        return {"original_state": original_state}
+        return {"original_state": original_state, **state}
     
     def _prepare_branch(self, state: dict[str, Any]) -> dict[str, Any]:
         original_state = state.get("original_state", {})
-        has_key_conflict = any(key in original_state for key in self.output_state_keys)
-        if has_key_conflict:
+        input_state = {
+            k: v for k, v in state.items() if k != "original_state"
+        }
+
+        input_conflict = any(k in original_state for k in input_state)
+        output_conflict = any(key in original_state for key in self.output_state_keys)
+        final_branch = self.branch_name
+
+        if input_conflict or output_conflict:
+            reason = "Input mismatch" if input_conflict else "Output key conflict"
             final_branch = self._create_branch_name()
-            logger.info(f"Key conflict detected. Created new branch: {final_branch}")
+            logger.info("%s detected. Created new branch: %s", reason, final_branch)
         else:
-            final_branch = self.branch_name
-            logger.info(f"No key conflict. Using existing branch: {final_branch}")
+            logger.info(f"No conflict. Using existing branch: {final_branch}")
+
         return {
-            "original_state": original_state, 
+            "original_state": original_state,
+            "input_state": input_state,
             "branch_name": final_branch, 
         }
 
     # @time_node("wrapper", "run_subgraph")
     def _run_subgraph(self, state: dict[str, Any]) -> dict[str, Any]:
         original_state = state.get("original_state") or {}
-        branch_name = state.get("branch_name")
+        input_state = state.get("input_state") if "input_state" in state else state
+        merged_input_state   = self._deep_merge(original_state, input_state)
+        branch_name = state.get("branch_name", self.branch_name)
+
         state_for_subgraph = {
-            **original_state,
+            **merged_input_state,
             "github_owner": self.github_owner, 
             "repository_name": self.repository_name, 
             "branch_name": branch_name, 
         }
+
+        missing = [k for k in self.input_state_keys if k not in state_for_subgraph]
+        if missing:
+            raise ValueError(
+                f"run_subgraph: required keys missing: {missing}. "
+                "Check perform_download flag or caller inputs."
+            )
+
         output_state = self.subgraph.invoke(state_for_subgraph)
         return {
-            "original_state": original_state,
+            "merged_input_state": merged_input_state,
             "output_state": output_state,
             "branch_name": branch_name, 
         }
 
     # @time_node("wrapper", "upload_to_github")
     def _upload_to_github(self, state: dict[str, Any]) -> dict[str, bool]:
-        original_state = state.get("original_state", {})
+        merged_input_state = state.get("merged_input_state", {})
         raw_output_state = state.get("output_state", {})
         branch_to_use = state.get("branch_name", self.branch_name)
         output_state = {
@@ -154,7 +179,7 @@ class GithubGraphWrapper:
             for k in self.output_state_keys
             if k in raw_output_state
         }
-        merged_state = self._deep_merge(original_state, output_state)
+        merged_output_state = self._deep_merge(merged_input_state, output_state)
 
         formatted_extra_files = self._format_extra_files(branch_to_use)
 
@@ -163,7 +188,7 @@ class GithubGraphWrapper:
             repository_name=self.repository_name,
             branch_name=branch_to_use,
             output_path=self.research_file_path,
-            state=merged_state,
+            state=merged_output_state,
             extra_files=formatted_extra_files,
             commit_message=f"Update by subgraph: {self.subgraph_name}",
         )
@@ -215,6 +240,7 @@ T = TypeVar("T", bound=BuildableSubgraph)
 # TODO: Add support for subgraph API invocation
 def create_wrapped_subgraph(
     subgraph: type[T],
+    input_state: type[Any], 
     output_state: type[Any],
 ) -> type:
     class GithubGraphRunner(GithubGraphWrapper):
@@ -239,6 +265,7 @@ def create_wrapped_subgraph(
             )
             super().__init__(
                 subgraph=compiled_subgraph,
+                input_state=input_state, 
                 output_state=output_state,
                 github_repository=github_repository,
                 branch_name=branch_name,

--- a/src/researchgraph/html_subgraph/html_subgraph.py
+++ b/src/researchgraph/html_subgraph/html_subgraph.py
@@ -76,7 +76,11 @@ class HtmlSubgraph:
         return graph_builder.compile()
 
 
-HtmlConverter = create_wrapped_subgraph(HtmlSubgraph, HtmlSubgraphOutputState)
+HtmlConverter = create_wrapped_subgraph(
+    HtmlSubgraph,
+    HtmlSubgraphInputState, 
+    HtmlSubgraphOutputState
+)
 
 
 if __name__ == "__main__":

--- a/src/researchgraph/latex_subgraph/latex_subgraph.py
+++ b/src/researchgraph/latex_subgraph/latex_subgraph.py
@@ -86,7 +86,11 @@ class LatexSubgraph:
         return graph_builder.compile()
     
 
-LatexConverter =  create_wrapped_subgraph(LatexSubgraph, LatexSubgraphOutputState)
+LatexConverter =  create_wrapped_subgraph(
+    LatexSubgraph, 
+    LatexSubgraphInputState, 
+    LatexSubgraphOutputState
+)
 
 
 if __name__ == "__main__":

--- a/src/researchgraph/retrieve_paper_subgraph/retrieve_paper_subgraph.py
+++ b/src/researchgraph/retrieve_paper_subgraph/retrieve_paper_subgraph.py
@@ -566,6 +566,7 @@ class RetrievePaperSubgraph:
 
 Retriever = create_wrapped_subgraph(
     RetrievePaperSubgraph,
+    RetrievePaperInputState, 
     RetrievePaperOutputState,
 )
 
@@ -581,8 +582,8 @@ if __name__ == "__main__":
     llm_name = "o3-mini-2025-01-31"
     save_dir = "/workspaces/researchgraph/data"
 
-    github_repository = "auto-res2/test20"
-    branch_name = "test"
+    github_repository = "auto-res2/experiment_script_matsuzawa"
+    branch_name = "base-branch"
     input = {
         "queries": ["diffusion model"],
     }

--- a/src/researchgraph/writer_subgraph/writer_subgraph.py
+++ b/src/researchgraph/writer_subgraph/writer_subgraph.py
@@ -86,7 +86,11 @@ class WriterSubgraph:
         return graph_builder.compile()
     
 
-PaperWriter = create_wrapped_subgraph(WriterSubgraph, WriterSubgraphOutputState)
+PaperWriter = create_wrapped_subgraph(
+    WriterSubgraph, 
+    WriterSubgraphInputState, 
+    WriterSubgraphOutputState
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Background & Purpose
The current `GithubGraphWrapper` design only utilizes research_history.json (downloaded from GitHub) as the input state. It did not support passing in additional input data from external sources. This limitation made it difficult to customize or override inputs dynamically.

✅ 1. External input support
You can now pass custom input data along with the GitHub state. This input is merged with research_history.json before subgraph execution.

✅ 2. Automatic branching on conflict
A new _prepare_branch() method detects key conflicts between input/output and the GitHub state. If needed, it creates a new branch automatically to avoid overwriting existing data.

Details of the implementation are described below:

<details>
<summary><code>1. src/researchgraph/github_utils/graph_wrapper.py</code></summary>

**Key Update**:
- Added input_state as a new TypedDict to clearly define expected external inputs.
- Introduced _prepare_branch() to:
  - Detect key conflicts between input and original state. 
  - Create a new branch if necessary.
- Updated _run_subgraph() to:
  - Merge original_state and input_state.
  - Validate required input_state_keys.
- Updated _upload_to_github() to use the merged input + output state.

</details>