### PR TITLE
Fix `FileNotFoundError` in `render_html` by creating save_dir

### DIFF
--- a/src/researchgraph/html_subgraph/nodes/render_html.py
+++ b/src/researchgraph/html_subgraph/nodes/render_html.py
@@ -65,6 +65,7 @@ def _wrap_in_html_template(paper_html_content: str) -> str:
     return template.render(content=paper_html_content)
 
 def _save_index_html(content: str, save_dir: str) -> None:
+    os.makedirs(save_dir, exist_ok=True)
     html_path = os.path.join(save_dir, "index.html")
     with open(html_path, "w", encoding="utf-8") as f:
         f.write(content)


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?
<!-- Delete any that don’t apply -->

- Minor content fixes (broken links, typos, etc.)


#### Description

- Closes #345 <!-- Add an issue number if this PR will close it. -->
- This PR fixes a bug where `render_html()` would raise a `FileNotFoundError` if `save_dir` did not already exist.
- The `_save_index_html()` now includes `os.makedirs(save_dir, exist_ok=True)` to ensure the output directory is created beforehand.
